### PR TITLE
Port validated Android persistent voxel cache

### DIFF
--- a/android_main.lua
+++ b/android_main.lua
@@ -1,0 +1,40 @@
+-- Dramatic Shape 1.8.2 Android optimization shim.
+--
+-- Keep upstream main.lua byte-for-byte intact.  This entry loads it and
+-- injects one module install immediately after ChunkMesher is created, so the
+-- Android patch rides the official 1.8.2 module graph instead of replacing it.
+
+local mod = ...
+local source = mod:read("main.lua")
+if not source then
+  error("DRAMATIC_SHAPE Android patch: main.lua is missing", 0)
+end
+
+-- Refuse an obviously wrong/old base instead of silently grafting the patch
+-- onto the 1.7.x tree it was originally developed against.
+local expected = {
+  'local ViewBox = V.require("ViewBox")',
+  'local SettingsMenu = V.require("SettingsMenu")',
+  'local LetsGo = V.require("LetsGo")',
+  'local Shiny = V.require("Shiny")',
+}
+for _, needle in ipairs(expected) do
+  if not source:find(needle, 1, true) then
+    error("DRAMATIC_SHAPE Android patch: this overlay requires official 1.8.2", 0)
+  end
+end
+
+local anchor = 'local ChunkMesher = V.require("ChunkMesher")'
+local a, b = source:find(anchor, 1, true)
+if not a then
+  error("DRAMATIC_SHAPE Android patch: ChunkMesher anchor not found", 0)
+end
+
+local injection = '\nV.require("AndroidOptimize").install(ChunkMesher, VoxelScene, Voxel)'
+source = source:sub(1, b) .. injection .. source:sub(b + 1)
+
+local chunk, err = load(source, "@" .. mod.path .. "/main.lua")
+if not chunk then
+  error("DRAMATIC_SHAPE Android patch: patched main.lua did not compile: " .. tostring(err), 0)
+end
+return chunk(mod)

--- a/lib/AndroidOptimize.lua
+++ b/lib/AndroidOptimize.lua
@@ -1,0 +1,590 @@
+-- Android performance layer for Dramatic Shape 1.8.2.
+--
+-- Deliberately implemented as wrappers around the official public ChunkMesher
+-- API.  The 1.8.2 geometry builders therefore remain authoritative: new door,
+-- wall, prop, Stadium, Let's Go, ViewBox, and other upstream geometry changes
+-- are never replaced by the older 1.7.x Android fork.
+--
+-- What this adds on Android:
+--   * resumable persistent BODY cache in LOVE's save directory;
+--   * LZ4-compressed independent vertex chunks, streamed incrementally;
+--   * current/facing/nearest cached-neighbour upload priority;
+--   * no heavy live meshing while normal walking is already fully 3D;
+--   * transition frames count as covered work time;
+
+local V = ...
+
+local M = {}
+local installed = false
+
+local function isAndroid()
+  return love and love.system and love.system.getOS
+         and love.system.getOS() == "Android"
+end
+
+local ffi = nil
+do
+  local ok, f = pcall(require, "ffi")
+  if ok then ffi = f end
+end
+
+local clock = (love and love.timer and love.timer.getTime) or os.clock
+local Budget = V.require("BuildBudget")
+local Voxel3D = V.require("Voxel3D")
+local Structures = V.require("Structures")
+
+local CACHE_VERSION = "182a1"
+local CACHE_DIR = "dramatic_shape/voxel_cache_" .. CACHE_VERSION
+local HEADER_BYTES = 64
+local CACHE_CHUNK_VERTS = 8192
+local VERTEX_FLOATS = 6
+local VERTEX_BYTES = VERTEX_FLOATS * 4
+
+local originals = {}
+local ext = {}          -- map id -> { fp, mapRef, body, water }
+
+local statusMemo = {}   -- map id -> { mapRef, fp, hit }
+local jobs = {}         -- disk BODY pair loads only
+local jobsById = {}
+local prevLive = {}
+
+local function safeId(id)
+  return tostring(id):gsub("[^%w_%-]", "_")
+end
+
+local function bodyPath(map, water)
+  return CACHE_DIR .. "/" .. safeId(map.id)
+         .. (water and "_body_water.dsvc" or "_body.dsvc")
+end
+
+local function okPath(map)
+  return CACHE_DIR .. "/" .. safeId(map.id) .. "_body.ok"
+end
+
+local function capable()
+  return isAndroid() and ffi and love and love.filesystem
+         and love.filesystem.write and love.filesystem.read
+         and love.filesystem.newFile and love.graphics and love.graphics.newMesh
+         and love.data and love.data.newByteData
+end
+
+local function ensureDir()
+  if not capable() then return false end
+  local ok = pcall(love.filesystem.createDirectory, CACHE_DIR)
+  return ok
+end
+
+-- Deterministic hash of the live map data the BODY build consumes.  Runtime
+-- block edits therefore invalidate a pristine disk entry without deleting it.
+local function mapFingerprint(map)
+  if not (map and map.def and map.tileAt) then return "0" end
+  local h = 5381
+  local function add(v)
+    h = (h * 65599 + (tonumber(v) or 0) + 257) % 4294967296
+  end
+  add(map.def.width); add(map.def.height)
+  local ts = tostring((map.tileset and map.tileset.id) or map.def.tileset or "?")
+  for i = 1, #ts do add(ts:byte(i)) end
+  local okTR, TileRenderer = pcall(require, "src.render.TileRenderer")
+  local vf = okTR and TileRenderer and tostring(TileRenderer.voidFill or "trees") or "trees"
+  for i = 1, #vf do add(vf:byte(i)) end
+  local tw = (map.def.width or 0) * 4
+  local th = (map.def.height or 0) * 4
+  for y = 0, th - 1 do
+    for x = 0, tw - 1 do
+      local ok, tile = pcall(map.tileAt, map, x, y)
+      add(ok and tile or 0)
+    end
+  end
+  return string.format("%08x", h)
+end
+
+local function fixedHeader(n, fp, chunks)
+  local core = ("DSVC|%s|%010d|%s|%06d\n"):format(
+      CACHE_VERSION, n, fp, chunks)
+  if #core > HEADER_BYTES then return nil end
+  return core .. string.rep(" ", HEADER_BYTES - #core)
+end
+
+local function parseHeader(head)
+  if type(head) ~= "string" or #head < HEADER_BYTES then return nil end
+  local ver, count, fp, chunks = head:match(
+      "^DSVC|([^|]+)|(%d+)|([0-9a-fA-F]+)|(%d+)\n")
+  if ver ~= CACHE_VERSION then return nil end
+  return tonumber(count), fp and fp:lower() or nil, tonumber(chunks)
+end
+
+local function openFile(path, mode)
+  local ok, f = pcall(love.filesystem.newFile, path)
+  if not ok or not f then return nil end
+  local okOpen, opened = pcall(f.open, f, mode)
+  if not okOpen or opened == false then return nil end
+  return f
+end
+
+local function readHeader(path)
+  if not capable() then return nil end
+  local f = openFile(path, "r")
+  if not f then return nil end
+  local ok, head = pcall(f.read, f, HEADER_BYTES)
+  pcall(f.close, f)
+  return ok and type(head) == "string" and head or nil
+end
+
+local function fileMatches(path, fp)
+  local n, got, chunks = parseHeader(readHeader(path))
+  return n ~= nil and chunks ~= nil and got == tostring(fp):lower()
+end
+
+local function releaseMesh(mesh)
+  if mesh and mesh.release then pcall(mesh.release, mesh) end
+end
+
+local function releaseExt(id)
+  local e = ext[id]
+  if not e then return end
+  releaseMesh(e.body)
+  releaseMesh(e.water)
+  ext[id] = nil
+end
+
+local function diskStatus(map)
+  if not (capable() and map and map.id) then return false, nil end
+  local memo = statusMemo[map.id]
+  if memo and memo.mapRef == map then return memo.hit, memo.fp end
+
+  local fp = mapFingerprint(map)
+  local markerOk = false
+  local okM, marker = pcall(love.filesystem.read, okPath(map))
+  if okM and type(marker) == "string" and marker == fp then markerOk = true end
+  local hit = markerOk
+              and fileMatches(bodyPath(map, false), fp)
+              and fileMatches(bodyPath(map, true), fp)
+  statusMemo[map.id] = { mapRef = map, fp = fp, hit = hit and true or false }
+  return hit, fp
+end
+
+local function writeMesh(path, mesh, fp)
+  if not ensureDir() then return false end
+  local n = mesh and mesh:getVertexCount() or 0
+  local chunks = (n == 0) and 0 or math.ceil(n / CACHE_CHUNK_VERTS)
+  local head = fixedHeader(n, fp, chunks)
+  if not head then return false end
+  local f = openFile(path, "w")
+  if not f then return false end
+
+  local ok, err = pcall(function()
+    assert(f:write(head) ~= false)
+    local at = 1
+    while at <= n do
+      local count = math.min(CACHE_CHUNK_VERTS, n - at + 1)
+      local buf = ffi.new("float[?]", count * VERTEX_FLOATS)
+      local p = 0
+      for i = 0, count - 1 do
+        local x, y, z, u, v, shade = mesh:getVertex(at + i)
+        buf[p] = x or 0;         buf[p + 1] = y or 0
+        buf[p + 2] = z or 0;     buf[p + 3] = u or 0
+        buf[p + 4] = v or 0;     buf[p + 5] = shade or 1
+        p = p + VERTEX_FLOATS
+        if i % 256 == 255 then Budget.check() end
+      end
+      local raw = ffi.string(buf, count * VERTEX_BYTES)
+      local mode, payload = "R", raw
+      if love.data and love.data.compress then
+        local okC, packed = pcall(love.data.compress, "string", "lz4", raw)
+        if okC and type(packed) == "string" and #packed < #raw then
+          mode, payload = "L", packed
+        end
+      end
+      assert(f:write(mode .. string.format("%08x", #payload)) ~= false)
+      assert(f:write(payload) ~= false)
+      at = at + count
+      Budget.check()
+    end
+  end)
+  pcall(f.close, f)
+  if not ok then
+    pcall(love.filesystem.remove, path)
+    return false, err
+  end
+  return true
+end
+
+local function loadMesh(path, expectedFp)
+  local f = openFile(path, "r")
+  if not f then return false, nil end
+  local okH, head = pcall(f.read, f, HEADER_BYTES)
+  if not okH then pcall(f.close, f); return false, nil end
+  local n, fp, chunks = parseHeader(head)
+  if n == nil or fp ~= tostring(expectedFp):lower() then
+    pcall(f.close, f)
+    return false, nil
+  end
+  if n == 0 then pcall(f.close, f); return true, nil end
+
+  local mesh = nil
+  local ok, err = pcall(function()
+    mesh = love.graphics.newMesh(Voxel3D.FORMAT, n, "triangles", "static")
+    local at = 0
+    for _ = 1, chunks do
+      local rec = f:read(9)
+      assert(type(rec) == "string" and #rec == 9)
+      local mode = rec:sub(1, 1)
+      local packedBytes = tonumber(rec:sub(2, 9), 16)
+      assert((mode == "R" or mode == "L") and packedBytes)
+      local payload = f:read(packedBytes)
+      assert(type(payload) == "string" and #payload == packedBytes)
+      local raw = payload
+      if mode == "L" then
+        raw = love.data.decompress("string", "lz4", payload)
+      end
+      local count = math.min(CACHE_CHUNK_VERTS, n - at)
+      local bytes = count * VERTEX_BYTES
+      assert(type(raw) == "string" and #raw == bytes)
+      local data = love.data.newByteData(bytes)
+      ffi.copy(data:getFFIPointer(), raw, bytes)
+      mesh:setVertices(data, at + 1)
+      data:release()
+      at = at + count
+      Budget.check()
+    end
+    assert(at == n)
+  end)
+  pcall(f.close, f)
+  if not ok then
+    releaseMesh(mesh)
+    return false, nil, err
+  end
+  return true, mesh
+end
+
+local function precompileBody(ChunkMesher, map)
+  if not (capable() and map and map.id) then return false, "unsupported" end
+  local hit, fp = diskStatus(map)
+  if hit then return true, "cached" end
+  ensureDir()
+
+  -- Official 1.8.2's build() remains the source of truth.  It uses the current
+  -- FFI geometry sink and therefore includes every upstream geometry fix.
+  local terrain, water = ChunkMesher.build(map, true, nil, true)
+  local okT, errT = writeMesh(bodyPath(map, false), terrain, fp)
+  local okW, errW = writeMesh(bodyPath(map, true), water, fp)
+  releaseMesh(terrain)
+  releaseMesh(water)
+  if not (okT and okW) then
+    pcall(love.filesystem.remove, bodyPath(map, false))
+    pcall(love.filesystem.remove, bodyPath(map, true))
+    pcall(love.filesystem.remove, okPath(map))
+    return false, errT or errW or "write failed"
+  end
+  local okMarker, wrote = pcall(love.filesystem.write, okPath(map), fp)
+  if not okMarker or wrote == false then return false, "marker write failed" end
+  statusMemo[map.id] = { mapRef = map, fp = fp, hit = true }
+  return true
+end
+
+local function queueDisk(map)
+  local hit, fp = diskStatus(map)
+  if not hit then return false end
+  local e = ext[map.id]
+  if e and e.fp == fp and e.mapRef == map and e.body ~= nil then return true end
+  local j = jobsById[map.id]
+  if j then
+    j.map = map
+    j.fp = fp
+    return true
+  end
+  j = { id = map.id, map = map, fp = fp }
+  jobsById[map.id] = j
+  jobs[#jobs + 1] = j
+  return true
+end
+
+local function finishDiskJob(job)
+  if jobsById[job.id] == job then jobsById[job.id] = nil end
+  for i = #jobs, 1, -1 do
+    if jobs[i] == job then table.remove(jobs, i); break end
+  end
+end
+
+local function runDiskJob(job)
+  local okT, terrain = loadMesh(bodyPath(job.map, false), job.fp)
+  if not okT then return false, "terrain cache read failed" end
+  local okW, water = loadMesh(bodyPath(job.map, true), job.fp)
+  if not okW then
+    releaseMesh(terrain)
+    return false, "water cache read failed"
+  end
+  if job.cancelled then
+    releaseMesh(terrain)
+    releaseMesh(water)
+    return false, "cancelled"
+  end
+  releaseExt(job.id)
+  ext[job.id] = { fp = job.fp, mapRef = job.map, body = terrain, water = water }
+  return true
+end
+
+local moveProbe = { map = nil, x = nil, y = nil, last = -math.huge }
+local MOVE_GRACE = 0.18
+local function moving(ow)
+  local p = ow and ow.player
+  if not (p and ow.map) then
+    moveProbe.map, moveProbe.x, moveProbe.y = nil, nil, nil
+    moveProbe.last = -math.huge
+    return false
+  end
+  local same = moveProbe.map == ow.map.id
+  local moved = same and moveProbe.x ~= nil
+                and (p.px ~= moveProbe.x or p.py ~= moveProbe.y)
+  local nowMoving = p.moving == true or moved
+  if nowMoving then moveProbe.last = clock() end
+  moveProbe.map, moveProbe.x, moveProbe.y = ow.map.id, p.px, p.py
+  return nowMoving or (same and (clock() - moveProbe.last) < MOVE_GRACE)
+end
+
+local function priorities(ow)
+  local pmap = {}
+  if not (ow and ow.map) then return pmap end
+  pmap[ow.map.id] = 100
+  local list = ow.neighbors or {}
+  if #list == 0 then return pmap end
+
+  local player = ow.player
+  local nearest, nearestD2 = nil, math.huge
+  local front, frontScore = nil, -math.huge
+  local fx, fy = 0, 0
+  local facing = player and player.facing
+  if facing == "up" then fy = -1
+  elseif facing == "down" then fy = 1
+  elseif facing == "left" then fx = -1
+  elseif facing == "right" then fx = 1 end
+
+  local cw = (ow.map.def.width or 0) * 32
+  local ch = (ow.map.def.height or 0) * 32
+  local ccx, ccy = cw * 0.5, ch * 0.5
+  for i, nb in ipairs(list) do
+    pmap[nb.map.id] = math.max(pmap[nb.map.id] or 0, 2)
+    if player then
+      local x1, y1 = nb.ox, nb.oy
+      local x2 = x1 + (nb.map.def.width or 0) * 32
+      local y2 = y1 + (nb.map.def.height or 0) * 32
+      local dx = (player.px < x1 and x1 - player.px)
+                 or (player.px > x2 and player.px - x2) or 0
+      local dy = (player.py < y1 and y1 - player.py)
+                 or (player.py > y2 and player.py - y2) or 0
+      local d2 = dx * dx + dy * dy
+      if d2 < nearestD2 then nearest, nearestD2 = i, d2 end
+      if fx ~= 0 or fy ~= 0 then
+        local ncx = nb.ox + (nb.map.def.width or 0) * 16
+        local ncy = nb.oy + (nb.map.def.height or 0) * 16
+        local vx, vy = ncx - ccx, ncy - ccy
+        local len = math.sqrt(vx * vx + vy * vy)
+        if len > 0 then
+          local score = (vx * fx + vy * fy) / len
+          if score > frontScore then front, frontScore = i, score end
+        end
+      end
+    end
+  end
+  if nearest and list[nearest] then pmap[list[nearest].map.id] = 4 end
+  if front and frontScore > 0.20 and list[front] then pmap[list[front].map.id] = 6 end
+  return pmap
+end
+
+local function pickDiskJob(ow)
+  if #jobs == 0 then return nil end
+  local prio = priorities(ow)
+  local pick, best = jobs[1], -math.huge
+  for _, j in ipairs(jobs) do
+    local v = prio[j.id] or 1
+    if v > best then pick, best = j, v end
+  end
+  return pick
+end
+
+local function pumpDisk(ow, covered, isMoving)
+  local job = pickDiskJob(ow)
+  if not job then return false end
+  if not job.co then
+    job.co = coroutine.create(function()
+      local ok, err = runDiskJob(job)
+      return ok, err
+    end)
+  end
+  local slice = covered and 0.030 or (isMoving and 0.00060 or 0.003)
+  Budget.begin(job.co, slice)
+  local ok, a, b = coroutine.resume(job.co)
+  Budget.finish()
+  if not ok then
+    statusMemo[job.id] = { mapRef = job.map, fp = job.fp, hit = false }
+    pcall(love.filesystem.remove, okPath(job.map))
+    finishDiskJob(job)
+    return true
+  end
+  if coroutine.status(job.co) == "dead" then
+    if not a and not job.cancelled then
+      statusMemo[job.id] = { mapRef = job.map, fp = job.fp, hit = false }
+      pcall(love.filesystem.remove, okPath(job.map))
+    end
+    finishDiskJob(job)
+  end
+  return true
+end
+
+function M.install(ChunkMesher, VoxelScene, Voxel)
+  if installed then return end
+  installed = true
+  if not isAndroid() then return end
+
+  originals.request = ChunkMesher.request
+  originals.pair = ChunkMesher.pair
+  originals.peek = ChunkMesher.peek
+  originals.pump = ChunkMesher.pump
+  originals.setLive = ChunkMesher.setLive
+  originals.invalidate = ChunkMesher.invalidate
+  originals.refresh = ChunkMesher.refresh
+
+  ChunkMesher.diskCacheCapable = capable
+  ChunkMesher.diskCacheDir = function() return CACHE_DIR end
+  ChunkMesher.diskCacheVersion = function() return CACHE_VERSION end
+  ChunkMesher.bodyCachedOnDisk = function(map)
+    local hit = diskStatus(map)
+    return hit and true or false
+  end
+  ChunkMesher.precompileBody = function(map)
+    return precompileBody(ChunkMesher, map)
+  end
+
+  -- A FULL request still goes to upstream, but also starts the cheaper cached
+  -- BODY immediately when available.  This is enough to make official
+  -- VoxelScene.prefetch() fall through from pair(full) to our pair(body)
+  -- without replacing any 1.8.2 scene code.
+  ChunkMesher.request = function(map, bodyOnly, masks, urgent, ...)
+    local onDisk = queueDisk(map)
+    if bodyOnly and onDisk then
+      local e = ext[map.id]
+      return e and e.body or nil
+    end
+    return originals.request(map, bodyOnly, masks, urgent, ...)
+  end
+
+  ChunkMesher.pair = function(map, bodyOnly)
+    local a, b = originals.pair(map, bodyOnly)
+    if a or not bodyOnly then return a, b end
+    local memo = statusMemo[map.id]
+    local e = ext[map.id]
+    if memo and memo.mapRef == map and e and e.fp == memo.fp and e.mapRef == map then
+      return e.body, e.water
+    end
+    return nil, nil
+  end
+
+  ChunkMesher.peek = function(map, bodyOnly)
+    local m = originals.peek(map, bodyOnly)
+    if m or not bodyOnly then return m end
+    local memo = statusMemo[map.id]
+    local e = ext[map.id]
+    if memo and memo.mapRef == map and e and e.fp == memo.fp and e.mapRef == map then
+      return e.body
+    end
+    return nil
+  end
+
+  ChunkMesher.setLive = function(live)
+    originals.setLive(live)
+    for id in pairs(ext) do
+      if not live[id] and not prevLive[id] then releaseExt(id) end
+    end
+    for i = #jobs, 1, -1 do
+      local j = jobs[i]
+      if not live[j.id] and not prevLive[j.id] then
+        if j.co then
+          j.cancelled = true
+          if jobsById[j.id] == j then jobsById[j.id] = nil end
+        else
+          if jobsById[j.id] == j then jobsById[j.id] = nil end
+          table.remove(jobs, i)
+        end
+      end
+    end
+    prevLive = live
+  end
+
+  ChunkMesher.invalidate = function(mapId)
+    if mapId then
+      releaseExt(mapId)
+      statusMemo[mapId] = nil
+      local j = jobsById[mapId]
+      if j then
+        if j.co then
+          j.cancelled = true
+          jobsById[mapId] = nil
+        else
+          finishDiskJob(j)
+        end
+      end
+    else
+      for id in pairs(ext) do releaseExt(id) end
+      ext, statusMemo = {}, {}
+      jobs, jobsById = {}, {}
+      prevLive = {}
+    end
+    return originals.invalidate(mapId)
+  end
+
+  ChunkMesher.refresh = function(mapId)
+    if mapId then
+      releaseExt(mapId)
+      statusMemo[mapId] = nil
+      local j = jobsById[mapId]
+      if j then
+        if j.co then
+          j.cancelled = true
+          jobsById[mapId] = nil
+        else
+          finishDiskJob(j)
+        end
+      end
+    end
+    return originals.refresh(mapId)
+  end
+
+  local CacheScreen = V.require("VoxelCacheScreen")
+  ChunkMesher.pump = function(covered, ...)
+    local okG, Game = pcall(require, "src.core.Game")
+    local ow = okG and Game and Game.overworld or nil
+    covered = (covered or (ow and ow.transitioning)) and true or false
+
+    -- First activation: move expensive map compilation to its own opaque,
+    -- resumable screen.  Do not let the ordinary runtime queue compete with it.
+    if CacheScreen.maybePush() or CacheScreen.active() then return end
+
+    local isMoving = not covered and moving(ow)
+    pumpDisk(ow, covered, isMoving)
+
+    -- If the CURRENT map is coming from disk, never race that cheap upload
+    -- against an upstream live FULL build.  The next prefetch sees the loaded
+    -- BODY and flips Voxel.ready; only then may hidden/idle refinement resume.
+    if ow and ow.map and not (Voxel and Voxel.ready) then
+      local j = jobsById[ow.map.id]
+      local e = ext[ow.map.id]
+      if j or (e and e.body) then return end
+    end
+
+    -- Once terrain is visible, live geometry generation is background work on
+    -- Android and waits for idle/covered time. Cached BODY uploads remain safe
+    -- during walking because they are chunked and tightly budgeted above.
+    if isMoving and Voxel and Voxel.ready then return end
+
+    return originals.pump(covered, ...)
+  end
+
+  pcall(function()
+    if V.mod and V.mod.log and V.mod.log.info then
+      V.mod.log:info("Android optimizer active: persistent BODY cache %s", CACHE_VERSION)
+    end
+  end)
+end
+
+return M

--- a/lib/AndroidOptimize.lua
+++ b/lib/AndroidOptimize.lua
@@ -11,6 +11,7 @@
 --   * current/facing/nearest cached-neighbour upload priority;
 --   * no heavy live meshing while normal walking is already fully 3D;
 --   * transition frames count as covered work time;
+--   * lighter shadow-map ladder and 120 Hz shadow rebuild throttling.
 
 local V = ...
 
@@ -432,6 +433,48 @@ local function pumpDisk(ow, covered, isMoving)
   return true
 end
 
+local function installShadowTuning()
+  local ShadowMap = V.require("ShadowMap")
+  ShadowMap.SIZES = { 768, 1024, 1536 }
+  ShadowMap.TARGET = 0.60
+  ShadowMap.res = 768
+
+  -- Keep the world itself at the display refresh rate, but on a 120 Hz phone
+  -- do not demand a second full sun render less than 1/90 s after the last one.
+  -- Map changes always bypass the throttle.
+  local oldStale = ShadowMap.stale
+  local oldFinish = ShadowMap.finish
+  local oldInvalidate = ShadowMap.invalidate
+  local lastDrawAt = -math.huge
+  local lastMap = nil
+
+  ShadowMap.stale = function(sig, ...)
+    local stale = oldStale(sig, ...)
+    if not stale then return false end
+    local okG, Game = pcall(require, "src.core.Game")
+    local mapId = okG and Game and Game.overworld and Game.overworld.map
+                  and Game.overworld.map.id or nil
+    if mapId ~= nil and mapId == lastMap and (clock() - lastDrawAt) < (1 / 90) then
+      return false
+    end
+    return true
+  end
+
+  ShadowMap.finish = function(sig, ...)
+    local r = oldFinish(sig, ...)
+    local okG, Game = pcall(require, "src.core.Game")
+    lastMap = okG and Game and Game.overworld and Game.overworld.map
+              and Game.overworld.map.id or nil
+    lastDrawAt = clock()
+    return r
+  end
+
+  ShadowMap.invalidate = function(...)
+    lastMap, lastDrawAt = nil, -math.huge
+    return oldInvalidate(...)
+  end
+end
+
 function M.install(ChunkMesher, VoxelScene, Voxel)
   if installed then return end
   installed = true
@@ -580,6 +623,7 @@ function M.install(ChunkMesher, VoxelScene, Voxel)
     return originals.pump(covered, ...)
   end
 
+  installShadowTuning()
   pcall(function()
     if V.mod and V.mod.log and V.mod.log.info then
       V.mod.log:info("Android optimizer active: persistent BODY cache %s", CACHE_VERSION)

--- a/lib/VoxelCacheScreen.lua
+++ b/lib/VoxelCacheScreen.lua
@@ -1,0 +1,262 @@
+-- Android V18: one-time persistent voxel BODY precompiler.
+--
+-- Heavy route/town meshes are the one thing a 120 Hz gameplay frame cannot
+-- hide: build them while walking and the player feels stutter; build them at a
+-- seam and they see void/2D; build them synchronously behind a door and the
+-- transition freezes.  So pay that cost once, on an explicit opaque loading
+-- screen, then keep the raw BODY vertex streams in LOVE's save directory.
+--
+-- The cache is resumable.  Every map is its own fingerprinted file; closing
+-- the app halfway through simply means the next run skips what is already
+-- valid and continues the missing maps.
+
+local V = ...
+
+local ChunkMesher = V.require("ChunkMesher")
+local Budget = V.require("BuildBudget")
+local Structures = V.require("Structures")
+
+local Screen = {}
+Screen.__index = Screen
+Screen.isOpaque = true
+
+local W, H = 160, 144
+local MIN_AREA = 24       -- blocks; catches routes/towns/forest, skips tiny rooms
+local SLICE = 0.018       -- loading-screen CPU budget per visible frame
+local HOLD = 0.65
+
+local asked = false
+local active = false
+
+local Font
+local function font()
+  if Font then return Font end
+  local ok, F = pcall(require, "src.render.Font")
+  if ok then Font = F end
+  return Font
+end
+
+local function text(str, x, y)
+  local F = font()
+  if not F then return end
+  love.graphics.setColor(0, 0, 0, 1)
+  F.draw(tostring(str), math.floor(x), math.floor(y))
+end
+
+local function centred(str, y)
+  local F = font()
+  if not F then return end
+  str = tostring(str)
+  text(str, (W - F.width(str)) / 2, y)
+end
+
+local function cacheSignature()
+  local vf = "trees"
+  local ok, TR = pcall(require, "src.render.TileRenderer")
+  if ok and TR then vf = tostring(TR.voidFill or vf) end
+  return tostring(ChunkMesher.diskCacheVersion()) .. "|" .. vf
+end
+
+local function markerPath()
+  return ChunkMesher.diskCacheDir() .. "/complete"
+end
+
+local function markerMatches()
+  if not (love and love.filesystem) then return false end
+  local ok, body = pcall(love.filesystem.read, markerPath())
+  return ok and type(body) == "string" and body == cacheSignature()
+end
+
+local function writeMarker()
+  pcall(love.filesystem.createDirectory, ChunkMesher.diskCacheDir())
+  pcall(love.filesystem.write, markerPath(), cacheSignature())
+end
+
+local function candidateIds(game)
+  local out = {}
+  local maps = game and game.data and game.data.maps or {}
+  for id, def in pairs(maps) do
+    local w = type(def) == "table" and tonumber(def.width) or nil
+    local h = type(def) == "table" and tonumber(def.height) or nil
+    -- Some engine revisions leave dimensions to MapLoader. Keep those ids and
+    -- decide after load rather than silently missing an outdoor map.
+    if not (w and h) or w * h >= MIN_AREA then out[#out + 1] = id end
+  end
+  table.sort(out, function(a, b) return tostring(a) < tostring(b) end)
+  return out
+end
+
+function Screen.new(game)
+  return setmetatable({
+    game = game,
+    ids = candidateIds(game),
+    index = 1,
+    done = 0,
+    built = 0,
+    skipped = 0,
+    current = nil,
+    currentName = "",
+    co = nil,
+    hold = 0,
+    finished = false,
+    failed = 0,
+  }, Screen)
+end
+
+function Screen:enter()
+  active = true
+end
+
+local function pop(self)
+  active = false
+  if self.game and self.game.stack and self.game.stack:top() == self then
+    self.game.stack:pop()
+  end
+end
+
+local function nextMap(self)
+  local MapLoader = require("src.world.MapLoader")
+  while self.index <= #self.ids do
+    local id = self.ids[self.index]
+    self.index = self.index + 1
+    local ok, map = pcall(MapLoader.load, self.game.data, id)
+    if ok and map and map.def then
+      local area = (tonumber(map.def.width) or 0) * (tonumber(map.def.height) or 0)
+      if area >= MIN_AREA then
+        self.current = map
+        self.currentName = tostring(map.id or id)
+        if ChunkMesher.bodyCachedOnDisk(map) then
+          self.done = self.done + 1
+          self.skipped = self.skipped + 1
+          Structures.invalidate(map.id)
+          self.current = nil
+        else
+          self.co = coroutine.create(function()
+            return ChunkMesher.precompileBody(map)
+          end)
+          return true
+        end
+      else
+        self.done = self.done + 1
+      end
+    else
+      self.done = self.done + 1
+      self.failed = self.failed + 1
+    end
+  end
+  return false
+end
+
+function Screen:update()
+  if self.finished then
+    self.hold = self.hold + 1 / 60
+    if self.hold >= HOLD then pop(self) end
+    return
+  end
+
+  -- B/Back skips this run.  No completion marker is written, so the next boot
+  -- resumes exactly where the per-map cache files left off.
+  local input = self.game and self.game.input
+  if input and input.wasPressed and input:wasPressed("b") then
+    pop(self)
+    return
+  end
+
+  if not self.co then
+    if not nextMap(self) then
+      if self.failed == 0 then writeMarker() end
+      self.finished = true
+      self.hold = 0
+      return
+    end
+    if not self.co then return end
+  end
+
+  Budget.begin(self.co, SLICE)
+  local ok, a, b = coroutine.resume(self.co)
+  Budget.finish()
+  if not ok then
+    self.failed = self.failed + 1
+    V.mod.log:warn("voxel cache: %s failed: %s", tostring(self.currentName), tostring(a))
+  end
+
+  if (not ok) or coroutine.status(self.co) == "dead" then
+    if ok and a then self.built = self.built + 1 else self.failed = self.failed + (ok and 1 or 0) end
+    self.done = self.done + 1
+    if self.current and self.current.id then Structures.invalidate(self.current.id) end
+    self.current, self.co = nil, nil
+    -- Keep the loading screen's memory flat after a route-sized raw buffer was
+    -- compressed/written and its Structures analysis was dropped.
+    collectgarbage("step", 300)
+  end
+end
+
+function Screen:onKeyPressed(key)
+  if key == "escape" or key == "backspace" or key == "x" then
+    pop(self)
+    return true
+  end
+  return false
+end
+
+function Screen:draw()
+  love.graphics.setColor(0.93, 0.94, 0.90, 1)
+  love.graphics.rectangle("fill", 0, 0, W, H)
+  centred("VOXEL CACHE", 18)
+  centred("ONE-TIME SETUP", 32)
+
+  local total = math.max(1, #self.ids)
+  local frac = math.max(0, math.min(1, self.done / total))
+  if self.finished then frac = 1 end
+  local bx, by, bw, bh = 20, 66, 120, 9
+  love.graphics.setColor(0.06, 0.05, 0.09, 1)
+  love.graphics.rectangle("fill", bx - 1, by - 1, bw + 2, bh + 2)
+  love.graphics.setColor(0.93, 0.94, 0.90, 1)
+  love.graphics.rectangle("fill", bx, by, bw, bh)
+  love.graphics.setColor(0.06, 0.05, 0.09, 1)
+  love.graphics.rectangle("fill", bx, by, math.floor(bw * frac + 0.5), bh)
+
+  if self.finished then
+    if self.failed == 0 then
+      centred("READY", 86)
+      centred("3D MAPS CACHED", 100)
+    else
+      centred("CACHE PARTIAL", 86)
+      centred(("%d FAILED"):format(self.failed), 100)
+    end
+  else
+    centred(("%d/%d"):format(self.done, #self.ids), 84)
+    if self.currentName ~= "" then
+      local name = self.currentName
+      if #name > 18 then name = name:sub(1, 18) end
+      centred(name, 98)
+    else
+      centred("SCANNING MAPS", 98)
+    end
+    centred("KEEP APP OPEN", 112)
+    centred("B: SKIP FOR NOW", 128)
+  end
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+function Screen.active() return active end
+
+function Screen.maybePush()
+  if asked then return false end
+  if not ChunkMesher.diskCacheCapable() then asked = true; return false end
+  local ok, Game = pcall(require, "src.core.Game")
+  if not (ok and Game and Game.stack and Game.overworld) then return false end
+  if Game.stack:top() ~= Game.overworld then return false end
+  local okV, Voxel = pcall(V.require, "VoxelState")
+  if not (okV and Voxel and Voxel.active and Voxel.active()) then return false end
+  asked = true
+  if markerMatches() then return false end
+  Game.stack:push(Screen.new(Game))
+  return true
+end
+
+function Screen._reset()
+  asked, active = false, false
+end
+
+return Screen

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Dramatic Shape Voxel Mod",
   "version": "1.8.2",
   "api": 2,
-  "entry": "main.lua",
+  "entry": "android_main.lua",
   "profile": "content",
   "category": "GRAPHICS",
   "game_version": "0.0.0-dev || >=0.1.37 <2.0.0",

--- a/tests/android_optimize_test.lua
+++ b/tests/android_optimize_test.lua
@@ -1,0 +1,476 @@
+-- Headless regression coverage for the validated Android optimization shim.
+-- Run from the mod repository root with:
+--   luajit tests/android_optimize_test.lua
+
+local ffi = require("ffi")
+
+local passed = 0
+local function check(value, message)
+  if not value then error(message or "check failed", 2) end
+end
+
+local function eq(actual, expected, message)
+  if actual ~= expected then
+    error((message or "values differ") .. ": expected " .. tostring(expected)
+          .. ", got " .. tostring(actual), 2)
+  end
+end
+
+local function near(actual, expected, epsilon, message)
+  if math.abs(actual - expected) > epsilon then
+    error((message or "values differ") .. ": expected " .. tostring(expected)
+          .. ", got " .. tostring(actual), 2)
+  end
+end
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if not ok then
+    io.stderr:write("FAIL ", name, ": ", tostring(err), "\n")
+    os.exit(1)
+  end
+  passed = passed + 1
+  io.write("ok   ", name, "\n")
+end
+
+local function newFilesystem()
+  local fs = { files = {}, readOpens = {} }
+
+  function fs.createDirectory() return true end
+  function fs.write(path, body)
+    fs.files[path] = body
+    return true
+  end
+  function fs.read(path) return fs.files[path] end
+  function fs.remove(path)
+    fs.files[path] = nil
+    return true
+  end
+  function fs.newFile(path)
+    local file = { path = path, pos = 1 }
+    function file:open(mode)
+      self.pos = 1
+      if mode == "w" then
+        fs.files[path] = ""
+      else
+        fs.readOpens[#fs.readOpens + 1] = path
+        if fs.files[path] == nil then return false end
+      end
+      return true
+    end
+    function file:write(body)
+      fs.files[path] = (fs.files[path] or "") .. body
+      return true
+    end
+    function file:read(bytes)
+      local body = fs.files[path]
+      if body == nil then return nil end
+      if bytes == nil then
+        local out = body:sub(self.pos)
+        self.pos = #body + 1
+        return out
+      end
+      local out = body:sub(self.pos, self.pos + bytes - 1)
+      self.pos = self.pos + #out
+      return out
+    end
+    function file:close() return true end
+    return file
+  end
+
+  return fs
+end
+
+local function sourceMesh(seed)
+  local mesh = { released = false }
+  function mesh:getVertexCount() return 6 end
+  function mesh:getVertex(i)
+    return seed + i, i * 2, i * 3, i / 10, i / 20, 0.5
+  end
+  function mesh:release() self.released = true end
+  return mesh
+end
+
+local function newChunkMesher()
+  local cm = {
+    requests = {}, pumps = {}, invalidates = {}, refreshes = {},
+    live = {},
+  }
+  function cm.build()
+    return sourceMesh(10), sourceMesh(20)
+  end
+  function cm.request(map, bodyOnly, masks, urgent)
+    cm.requests[#cm.requests + 1] = {
+      id = map.id, bodyOnly = bodyOnly, masks = masks, urgent = urgent,
+    }
+  end
+  function cm.pair() return nil, nil end
+  function cm.peek() return nil end
+  function cm.pump(covered)
+    cm.pumps[#cm.pumps + 1] = covered and true or false
+  end
+  function cm.setLive(live) cm.live = live end
+  function cm.invalidate(mapId)
+    cm.invalidates[#cm.invalidates + 1] = mapId or "*"
+  end
+  function cm.refresh(mapId)
+    cm.refreshes[#cm.refreshes + 1] = mapId
+  end
+  return cm
+end
+
+local function map(id, ox)
+  local tiles = {}
+  for i = 1, 16 do tiles[i] = i + (ox or 0) end
+  local m = {
+    id = id,
+    def = { width = 1, height = 1, tileset = "OVERWORLD" },
+    tileset = { id = "OVERWORLD" },
+    tiles = tiles,
+  }
+  function m:tileAt(x, y) return self.tiles[y * 4 + x + 1] end
+  return m
+end
+
+local function install(options)
+  options = options or {}
+  local fs = options.fs or newFilesystem()
+  local now = options.now or { value = 0 }
+  local slices = {}
+  local created = {}
+  local tileRenderer = options.tileRenderer or { voidFill = "trees" }
+  local structures = { invalidates = {} }
+  function structures.invalidate(id)
+    structures.invalidates[#structures.invalidates + 1] = id or "*"
+  end
+  local budget = {}
+  function budget.begin(_, slice) slices[#slices + 1] = slice end
+  function budget.finish() end
+  function budget.check() end
+
+  local graphics = {}
+  function graphics.newMesh(_, count)
+    local mesh = { count = count, uploads = {}, released = false }
+    function mesh:setVertices(data, at)
+      self.uploads[#self.uploads + 1] = { bytes = data.bytes, at = at }
+    end
+    function mesh:release() self.released = true end
+    created[#created + 1] = mesh
+    return mesh
+  end
+
+  local data = {}
+  -- Deliberately larger than raw: exercises the validated raw fallback.
+  function data.compress(container, codec, raw) return raw .. "x" end
+  function data.decompress(container, codec, raw) return raw end
+  function data.newByteData(bytes)
+    local storage = ffi.new("uint8_t[?]", bytes)
+    return {
+      bytes = bytes,
+      getFFIPointer = function() return storage end,
+      release = function() end,
+    }
+  end
+
+  _G.love = {
+    system = { getOS = function() return options.os or "Android" end },
+    timer = { getTime = function() return now.value end },
+    filesystem = fs,
+    graphics = graphics,
+    data = data,
+  }
+  package.loaded["src.render.TileRenderer"] = tileRenderer
+  package.loaded["src.core.Game"] = options.game
+
+  local cacheScreen = options.cacheScreen or {
+    maybePush = function() return false end,
+    active = function() return false end,
+  }
+  local shadowMap = options.shadowMap or {
+    SIZES = { 1024, 1536, 2048 }, TARGET = 0.45, res = 1024,
+    stale = function() return false end,
+    finish = function() end,
+    invalidate = function() end,
+  }
+  local voxel = options.voxel or { ready = false }
+  local modules = {
+    BuildBudget = budget,
+    Voxel3D = { FORMAT = { { "VertexPosition", "float", 3 } } },
+    Structures = structures,
+    VoxelCacheScreen = cacheScreen,
+    ShadowMap = shadowMap,
+  }
+  local V = {
+    mod = { log = { info = function() end, warn = function() end } },
+  }
+  function V.require(name)
+    local value = modules[name]
+    if value == nil then error("unexpected V.require: " .. tostring(name)) end
+    return value
+  end
+
+  local cm = options.chunkMesher or newChunkMesher()
+  local optimizer = assert(loadfile("lib/AndroidOptimize.lua"))(V)
+  optimizer.install(cm, {}, voxel)
+  return {
+    cm = cm, fs = fs, now = now, slices = slices, created = created,
+    tileRenderer = tileRenderer, structures = structures, voxel = voxel,
+    shadowMap = shadowMap,
+  }
+end
+
+test("entry shim injects the optimizer without replacing upstream main", function()
+  local installs = 0
+  local V = {}
+  function V.require(name)
+    if name == "AndroidOptimize" then
+      return { install = function() installs = installs + 1 end }
+    end
+    return { name = name }
+  end
+  local source = [[
+local mod = ...
+local V = mod.V
+local VoxelScene = V.require("VoxelScene")
+local Voxel = V.require("VoxelState")
+local ChunkMesher = V.require("ChunkMesher")
+local ViewBox = V.require("ViewBox")
+local SettingsMenu = V.require("SettingsMenu")
+local LetsGo = V.require("LetsGo")
+local Shiny = V.require("Shiny")
+return ChunkMesher.name
+]]
+  local mod = { V = V, path = "test-mod", read = function() return source end }
+  local result = assert(loadfile("android_main.lua"))(mod)
+  eq(result, "ChunkMesher", "upstream main result")
+  eq(installs, 1, "optimizer injection count")
+end)
+
+test("desktop path is unchanged", function()
+  local cm = newChunkMesher()
+  local request, pump = cm.request, cm.pump
+  local shadow = { SIZES = { 1024, 1536, 2048 }, TARGET = 0.45, res = 1024 }
+  install({ os = "Windows", chunkMesher = cm, shadowMap = shadow })
+  eq(cm.request, request, "desktop request")
+  eq(cm.pump, pump, "desktop pump")
+  eq(cm.diskCacheCapable, nil, "desktop cache API")
+  eq(shadow.SIZES[1], 1024, "desktop shadow ladder")
+  eq(shadow.TARGET, 0.45, "desktop shadow target")
+end)
+
+test("BODY cache fingerprint, header, invalidation, and restart", function()
+  local ctx = install()
+  local m = map("MAP A")
+  local ok, status = ctx.cm.precompileBody(m)
+  check(ok and status == nil, "first precompile")
+
+  local dir = "dramatic_shape/voxel_cache_182a1"
+  local terrainPath = dir .. "/MAP_A_body.dsvc"
+  local waterPath = dir .. "/MAP_A_body_water.dsvc"
+  local markerPath = dir .. "/MAP_A_body.ok"
+  local marker1 = ctx.fs.files[markerPath]
+  check(marker1 and #marker1 == 8, "fingerprint marker")
+  check(ctx.cm.bodyCachedOnDisk(m), "fresh cache hit")
+  check(ctx.fs.files[waterPath], "water cache exists")
+
+  local head = ctx.fs.files[terrainPath]:sub(1, 64)
+  eq(#head, 64, "fixed header size")
+  check(head:match("^DSVC|182a1|0000000006|" .. marker1 .. "|000001\n"),
+        "versioned cache header")
+  eq(ctx.fs.files[terrainPath]:sub(65, 65), "R", "raw fallback record")
+
+  ctx.cm.invalidate(m.id)
+  check(ctx.cm.bodyCachedOnDisk(m), "stable fingerprint after invalidation")
+  eq(ctx.fs.files[markerPath], marker1, "stable marker")
+
+  m.tiles[1] = m.tiles[1] + 1
+  ctx.cm.refresh(m.id)
+  check(not ctx.cm.bodyCachedOnDisk(m), "tile edit invalidates disk hit")
+  check(ctx.cm.precompileBody(m), "recompile edited map")
+  local marker2 = ctx.fs.files[markerPath]
+  check(marker2 ~= marker1, "tile edit changes fingerprint")
+
+  local restarted = install({ fs = ctx.fs, tileRenderer = ctx.tileRenderer })
+  check(restarted.cm.bodyCachedOnDisk(m), "cache survives module restart")
+  restarted.tileRenderer.voidFill = "water"
+  restarted.cm.refresh(m.id)
+  check(not restarted.cm.bodyCachedOnDisk(m), "void-fill invalidates disk hit")
+end)
+
+test("current, facing, nearest, and other disk jobs keep validated budgets", function()
+  local current = map("CURRENT", 0)
+  local nearest = map("NEAREST", 20)
+  local other = map("OTHER", 40)
+  local front = map("FRONT", 60)
+  local cold = map("COLD", 80)
+  local ow = {
+    map = current,
+    player = { px = 16, py = 16, facing = "right", moving = true },
+    neighbors = {
+      { map = nearest, ox = 0, oy = -32 },
+      { map = other, ox = -32, oy = 0 },
+      { map = front, ox = 32, oy = 0 },
+    },
+    transitioning = false,
+  }
+  local game = { overworld = ow }
+  local ctx = install({ game = game })
+  for _, m in ipairs({ current, nearest, other, front }) do
+    check(ctx.cm.precompileBody(m), "precompile " .. m.id)
+  end
+
+  ctx.cm.request(current, false, nil, true)
+  ctx.cm.request(nearest, true)
+  ctx.cm.request(other, true)
+  ctx.cm.request(front, true)
+  ctx.fs.readOpens = {}
+  ctx.slices = ctx.slices
+
+  ctx.cm.pump(false)
+  check(ctx.fs.readOpens[1]:find("CURRENT_body.dsvc", 1, true),
+        "current map loads first")
+  near(ctx.slices[#ctx.slices], 0.00060, 1e-9, "walking cached budget")
+  eq(#ctx.cm.pumps, 0, "FULL build does not race current disk BODY")
+  local currentBody = ctx.cm.pair(current, true)
+  check(currentBody ~= nil, "current cached BODY is drawable")
+
+  ctx.voxel.ready = true
+  ctx.fs.readOpens = {}
+  ctx.cm.pump(false)
+  check(ctx.fs.readOpens[1]:find("FRONT_body.dsvc", 1, true),
+        "facing neighbour precedes nearer frontier")
+  near(ctx.slices[#ctx.slices], 0.00060, 1e-9, "facing walking budget")
+
+  ow.player.moving = false
+  ctx.now.value = 0.5
+  ctx.fs.readOpens = {}
+  ctx.cm.pump(false)
+  check(ctx.fs.readOpens[1]:find("NEAREST_body.dsvc", 1, true),
+        "nearest frontier follows facing neighbour")
+  near(ctx.slices[#ctx.slices], 0.003, 1e-9, "idle cached budget")
+
+  ow.transitioning = true
+  ctx.fs.readOpens = {}
+  ctx.cm.pump(false)
+  check(ctx.fs.readOpens[1]:find("OTHER_body.dsvc", 1, true),
+        "remaining cached neighbour follows")
+  near(ctx.slices[#ctx.slices], 0.030, 1e-9, "transition cached budget")
+  eq(ctx.cm.pumps[#ctx.cm.pumps], true, "overworld.transitioning is covered")
+
+  ow.transitioning = false
+  ow.player.moving = true
+  ctx.cm.request(cold, true)
+  local before = #ctx.cm.pumps
+  ctx.cm.pump(false)
+  eq(#ctx.cm.pumps, before, "cold heavy work pauses while walking")
+  ow.player.moving = false
+  ctx.now.value = 1.0
+  ctx.cm.pump(false)
+  eq(#ctx.cm.pumps, before + 1, "cold heavy work resumes while idle")
+end)
+
+test("one-time cache resumes and writes complete only after a clean pass", function()
+  local fs = newFilesystem()
+  local cached, builds = {}, {}
+  local cm = {}
+  function cm.diskCacheCapable() return true end
+  function cm.diskCacheDir() return "dramatic_shape/voxel_cache_182a1" end
+  function cm.diskCacheVersion() return "182a1" end
+  function cm.bodyCachedOnDisk(m) return cached[m.id] == true end
+  function cm.precompileBody(m)
+    builds[m.id] = (builds[m.id] or 0) + 1
+    cached[m.id] = true
+    return true
+  end
+  local budget = { begin = function() end, finish = function() end }
+  local structures = { invalidate = function() end }
+  local voxel = { active = function() return true end }
+  local maps = { A = map("A"), B = map("B") }
+  maps.A.def.width, maps.A.def.height = 6, 4
+  maps.B.def.width, maps.B.def.height = 8, 4
+  local overworld = {}
+  local stack = { items = { overworld } }
+  function stack:top() return self.items[#self.items] end
+  function stack:push(value) self.items[#self.items + 1] = value; value:enter() end
+  function stack:pop() table.remove(self.items) end
+  local skip = false
+  local game = {
+    data = { maps = { A = maps.A.def, B = maps.B.def } },
+    overworld = overworld,
+    stack = stack,
+    input = { wasPressed = function(_, key) return key == "b" and skip end },
+  }
+
+  _G.love = {
+    filesystem = fs,
+    graphics = { setColor = function() end, rectangle = function() end },
+  }
+  package.loaded["src.render.TileRenderer"] = { voidFill = "trees" }
+  package.loaded["src.core.Game"] = game
+  package.loaded["src.world.MapLoader"] = {
+    load = function(_, id) return maps[id] end,
+  }
+  local modules = {
+    ChunkMesher = cm, BuildBudget = budget, Structures = structures,
+    VoxelState = voxel,
+  }
+  local V = { mod = { log = { warn = function() end } } }
+  function V.require(name) return assert(modules[name], name) end
+  local Screen = assert(loadfile("lib/VoxelCacheScreen.lua"))(V)
+
+  check(Screen.maybePush(), "initial prebuild screen")
+  local first = stack:top()
+  first:update()
+  eq(builds.A, 1, "first map built")
+  skip = true
+  first:update()
+  eq(stack:top(), overworld, "B/Back defers setup")
+  eq(fs.files[cm.diskCacheDir() .. "/complete"], nil,
+     "interrupted pass has no global marker")
+
+  skip = false
+  Screen._reset()
+  check(Screen.maybePush(), "resumed prebuild screen")
+  local resumed = stack:top()
+  for _ = 1, 8 do
+    resumed:update()
+    if resumed.finished then break end
+  end
+  check(resumed.finished, "resumed pass finishes")
+  eq(builds.A, 1, "valid map skipped on resume")
+  eq(builds.B, 1, "missing map built on resume")
+  eq(fs.files[cm.diskCacheDir() .. "/complete"], "182a1|trees",
+     "complete marker written after clean pass")
+end)
+
+test("Android shadow ladder and 1/90 second pacing match the validated build", function()
+  local now = { value = 1 }
+  local game = { overworld = { map = { id = "MAP_A" } } }
+  local oldFinish, oldInvalidate = 0, 0
+  local shadow = {
+    SIZES = { 1024, 1536, 2048 }, TARGET = 0.45, res = 1024,
+    stale = function() return true end,
+    finish = function() oldFinish = oldFinish + 1; return "finished" end,
+    invalidate = function() oldInvalidate = oldInvalidate + 1 end,
+  }
+  install({ now = now, game = game, shadowMap = shadow })
+  eq(shadow.SIZES[1], 768, "Android shadow ladder first rung")
+  eq(shadow.SIZES[2], 1024, "Android shadow ladder second rung")
+  eq(shadow.SIZES[3], 1536, "Android shadow ladder third rung")
+  eq(shadow.TARGET, 0.60, "Android shadow target")
+  eq(shadow.res, 768, "Android initial shadow resolution")
+
+  eq(shadow.finish("base"), "finished", "wrapped finish result")
+  eq(oldFinish, 1, "original finish called")
+  now.value = 1.005
+  check(not shadow.stale("motion"), "same-map high-refresh pass throttled")
+  now.value = 1.020
+  check(shadow.stale("motion"), "same-map pass resumes after 1/90 second")
+  now.value = 1.006
+  game.overworld.map = { id = "MAP_B" }
+  check(shadow.stale("map-change"), "map changes bypass throttle")
+  shadow.invalidate()
+  eq(oldInvalidate, 1, "original invalidate called")
+end)
+
+io.write(("PASS %d Android optimization tests\n"):format(passed))


### PR DESCRIPTION
## Summary

This ports the Android performance layer from the already field-tested `1.8.2-androidopt.1` build onto the community repository's current `dev` branch.

The Android issue is that large map geometry can otherwise be generated during visible frames. This port keeps the validated behavior:

- persistent fingerprinted BODY cache for terrain and its paired water mesh
- independent LZ4/raw chunks with progressive decompression and GPU upload
- resumable one-time `VOXEL CACHE` prebuild
- current-map disk cache priority
- directional cached-neighbour prefetch
- walking/idle/covered-transition work budgets
- Android-only shadow-map ladder and 1/90-second pacing

The cache fingerprint covers map dimensions, tileset, live tile contents, and void-fill. Cache invalidation remains connected to refresh/invalidate paths.

The upstream 1.8.2 implementation remains authoritative: the validated runtime overlay is injected after the existing `ChunkMesher` load instead of replacing current source files. Desktop exits the optimizer before installing any wrappers, preserving its existing rendering and shadow behavior.

No HUD, BattleHud, OverworldBattle, touch-control, ROM, proprietary asset, or unrelated mod change is included.

## Parity with 1.8.2-androidopt.1

| Behavior | Status |
| --- | --- |
| persistent BODY cache | preserved |
| cache survives restart | preserved |
| fingerprint invalidation | preserved |
| one-time prebuild | preserved |
| resume interrupted build | preserved |
| current-map disk cache priority | preserved |
| directional neighbour prefetch | preserved |
| walking budget | preserved |
| idle budget | preserved |
| transition budget | preserved |
| Android shadow pacing | preserved |
| desktop unaffected | preserved |

The three production overlay files are source-identical to the validated build after line-ending normalization. The only packaging adaptation is retaining the community repository's current manifest identity/version/description while changing its entry to the validated `android_main.lua` shim.

## Testing

Executed locally:

- LÖVE 11.5 / LuaJIT targeted suite: **6/6 passed**
  - entry shim injection
  - desktop no-op behavior
  - fingerprint stability and tile/void-fill invalidation
  - cache header/version/raw fallback and persistence across restart
  - current/front/nearest/other scheduler priority and walking/idle/transition budgets
  - interrupted prebuild resume and completion marker
  - Android shadow ladder and 1/90-second pacing
- Lua 5.1 syntax parsing with `luaparse`: **4/4 modified Lua files passed**
- `git diff --check upstream/dev...HEAD`: **passed**
- Existing upstream `tests/dramatic_shape_test.lua`: branch **1504/1530**, exactly matching unmodified `upstream/dev` (**1504/1530**, same 26 pre-existing fixture failures; Stadium model checks skipped because no proprietary model set is present)
- Existing `tests/voxel_figure_test.lua`: branch **102/121**, exactly matching unmodified `upstream/dev` (**102/121**, same 19 pre-existing failures)

The Android behavior was manually validated by the contributor on the source `1.8.2-androidopt.1` reference build. I did not perform a new physical-device Android test for this port. No ROM or proprietary data is included.