### PR TITLE
Add StadiumBattleFX voxel arena provider

### DIFF
--- a/lib/BattleScene.lua
+++ b/lib/BattleScene.lua
@@ -364,7 +364,7 @@ end
 
 local function castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh,
                            atlasFor, cards, token, host, neighbors,
-                           water, nbWater, groundY)
+                           water, nbWater, groundY, externalActors)
   if not ShadowMap.available() then return end
   local sig = shadowSignature(state, arena, terrain, nbMesh, token)
   if not ShadowMap.stale(sig) then return end
@@ -377,7 +377,9 @@ local function castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh,
     pcall(function()
       V.require("StadiumStage").cast(ShadowMap, arena, groundY or 0)
     end)
-    pcall(function() V.require("Stadium").cast(ShadowMap) end)
+    if not externalActors then
+      pcall(function() V.require("Stadium").cast(ShadowMap) end)
+    end
     ShadowMap.finish(sig)
     return
   end
@@ -421,7 +423,9 @@ local function castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh,
   -- the world -- a Gyarados at the water's edge should put a Gyarados on
   -- the water. Un-snugged for the same reason: snug is a bias for a card
   -- rooted to the ground plane, and a model has thickness of its own.
-  pcall(function() V.require("Stadium").cast(ShadowMap) end)
+  if not externalActors then
+    pcall(function() V.require("Stadium").cast(ShadowMap) end)
+  end
   -- the capture session's ball, by the same reasoning: real geometry, its
   -- shadow is half of what sells the arc
   local cap = BattleScene.capture
@@ -503,7 +507,7 @@ local function tickTiles()
   pcall(require("src.render.TileRenderer").tick)
 end
 
-function BattleScene.render(state, arena, textures, token)
+function BattleScene.render(state, arena, textures, token, drawActors)
   if not (state and state.map and arena) then return nil end
   if not Voxel3D.available() then return nil end
   tickTiles()
@@ -606,10 +610,15 @@ function BattleScene.render(state, arena, textures, token)
   -- and the real one is rebuilt inside the scene below.
   Voxel3D.camera = cam
   Voxel3D.viewProjection(cx, cy, vw, vh)
-  local cards = monCards(arena, groundY, textures)
+  -- When StadiumBattleFX hosts this arena it supplies the independently
+  -- selected actor renderer. Native cards and this mod's Stadium actors must
+  -- then stay out of both the shadow and colour passes.
+  local cards = drawActors and {} or monCards(arena, groundY, textures)
   Voxel3D.camera = nil
   castShadows(state, arena, terrain, nbMesh, cx, cy, vw, vh, atlasFor,
-              cards, token, host, neighbors, water, nbWater, groundY)
+                cards, drawActors and nil or token,
+                host, neighbors, water, nbWater, groundY,
+                drawActors ~= nil)
 
   -- An opaque void either way. Outdoors the camera is low enough that the
   -- horizon is genuinely in frame, so it is sky; indoors it is the dark end
@@ -711,7 +720,7 @@ function BattleScene.render(state, arena, textures, token)
     -- and no glass either: the cards wear the battle screen, not the
     -- tileset atlas, so the mask's coordinates mean nothing on them
     Voxel3D.glass(false)
-    for _, card in ipairs(monCards(arena, groundY, textures)) do
+    for _, card in ipairs(cards) do
       -- the sun stored this card snugged (castShadows), so its own shadow
       -- lookup must read the same snugged transform -- see ShadowMap.snug
       Voxel3D.draw(BattleBillboard.mesh(), card.tex, card.model,
@@ -724,10 +733,12 @@ function BattleScene.render(state, arena, textures, token)
     -- the depth test against the tile. They manage the wireframe and the
     -- glass mask around their own draws (StadiumRig), which is why this
     -- sits outside the pair above rather than inside it.
-    local okStadium, stadiumErr = pcall(function()
-      V.require("Stadium").draw(BattleBillboard.PULL)
-    end)
-    if not okStadium then V.require("Stadium").report(stadiumErr) end
+    if not drawActors then
+      local okStadium, stadiumErr = pcall(function()
+        V.require("Stadium").draw(BattleBillboard.PULL)
+      end)
+      if not okStadium then V.require("Stadium").report(stadiumErr) end
+    end
     -- the capture session's Poke Ball, still inside the flash window and
     -- with the mons' own camera-ward pull, so a ball crossing in front of
     -- a card wins the depth test the way a nearer thing should
@@ -777,6 +788,14 @@ function BattleScene.render(state, arena, textures, token)
                      Mat4.translate(nb.ox, 0, nb.oy), fpull,
                      ShadowMap.snug(Mat4.translate(nb.ox, 0, nb.oy)))
       end
+    end
+    if drawActors then
+      drawActors({
+        vp = Voxel3D.vp,
+        groundY = groundY,
+        width = pw,
+        height = ph,
+      })
     end
     local canvas = AntiAlias.resolve(Voxel3D.endScene(), pw, ph, "battle")
     if not canvas then return end

--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -586,6 +586,49 @@ function OverworldBattle.arena()
   return session and session.arena or nil
 end
 
+-- Optional StadiumBattleFX host path. It reuses this mod's map arena while
+-- leaving models and every other presentation slot independently selectable.
+function OverworldBattle.providerAvailable(expectedBattle)
+  return session ~= nil and session.arena ~= nil and not session.arena.discs
+    and (expectedBattle == nil or session.battle == nil
+      or session.battle == expectedBattle)
+end
+
+function OverworldBattle.providerBegin(expectedBattle)
+  if not OverworldBattle.providerAvailable(expectedBattle) then return false end
+  session.apiHosted = true
+  session.shot = nil
+  session.snapped = false
+  return true
+end
+
+function OverworldBattle.providerRender(expectedBattle, drawActors)
+  if not (session and session.apiHosted and type(drawActors) == "function") then
+    return nil
+  end
+  if expectedBattle ~= nil and session.battle ~= nil
+      and session.battle ~= expectedBattle then return nil end
+  session.battle = session.battle or expectedBattle
+  session.token = (session.token or 0) + 1
+  local ok, shot = pcall(BattleScene.render, session.state, session.arena,
+    nil, session.token, drawActors)
+  if not (ok and shot and shot.canvas) then return nil end
+  local y1 = shot.ly + shot.player[2] * shot.scale
+  local y2 = shot.ly + shot.enemy[2] * shot.scale
+  local focusY, band, range = BattleDOF.bandFor(y1, y2, shot.ph)
+  local okDof, blurred = pcall(BattleDOF.apply, shot.canvas,
+    focusY, band, range)
+  if okDof and blurred then shot.canvas = blurred end
+  return shot.canvas
+end
+
+function OverworldBattle.providerFinish()
+  if not session then return end
+  session.apiHosted = false
+  session.shot = nil
+  session.snapped = false
+end
+
 function OverworldBattle.finish()
   if not session then return end
   restoreCast()
@@ -654,6 +697,12 @@ function OverworldBattle.update(dt)
   -- the world pass is hidden behind the battle, so mesh builds get the wide
   -- slice: nothing visible can hitch on them
   ChunkMesher.pump(true)
+
+  if session.apiHosted then
+    session.shot = nil
+    session.snapped = false
+    return
+  end
 
   -- The STADIUM models, ahead of the pics, because what they decide is
   -- WHICH pics are needed: a side a model is standing on gets no billboard

--- a/lib/StadiumBattleFxProvider.lua
+++ b/lib/StadiumBattleFxProvider.lua
@@ -1,0 +1,65 @@
+-- Optional StadiumBattleFX Battle Presentation API v1 arena provider.
+
+local V = ...
+local OverworldBattle = V.require("OverworldBattle")
+local Provider = { registered = false, fallback = nil }
+
+local function findMod(id)
+  local finder = V.mod and V.mod.find
+  if type(finder) ~= "function" then return nil end
+  local ok, handle = pcall(finder, id)
+  if ok and handle then return handle end
+  ok, handle = pcall(finder, V.mod, id)
+  return ok and handle or nil
+end
+
+function Provider:arena(context)
+  if not OverworldBattle.providerAvailable(context and context.battle) then
+    return self.fallback
+  end
+  return OverworldBattle.arena()
+end
+
+function Provider:begin(context)
+  return OverworldBattle.providerBegin(context and context.battle)
+    or self.fallback
+end
+
+function Provider:render(context, arena, drawActors)
+  return OverworldBattle.providerRender(context and context.battle, drawActors)
+    or self.fallback
+end
+
+function Provider:finish()
+  OverworldBattle.providerFinish()
+end
+
+function Provider.register()
+  if Provider.registered then return true end
+  local handle = findMod("STADIUM_BATTLE_FX")
+  local api = handle and handle.exports and handle.exports.battles
+  if not (api and api.version == 1
+      and type(api.registerComponent) == "function") then return false end
+  Provider.fallback = api.FALLBACK
+  local ok, id = pcall(api.registerComponent, api, V.mod.id, "arena",
+    "voxel-map", {
+      label = "DRAMATIC SHAPE VOXEL MAP",
+      description = "Dramatic Shape's staged voxel-map arena; models and "
+        .. "other features remain independently selectable.",
+      provider = Provider,
+      available = function(context)
+        return OverworldBattle.providerAvailable(context and context.battle)
+      end,
+    })
+  if not ok then
+    if V.mod.log and V.mod.log.warn then
+      V.mod.log:warn("StadiumBattleFX arena registration failed: %s", tostring(id))
+    end
+    return false
+  end
+  Provider.registered = true
+  Provider.id = id
+  return true
+end
+
+return Provider

--- a/main.lua
+++ b/main.lua
@@ -87,6 +87,7 @@ local VoxelGrid = V.require("VoxelGrid")
 local WorldCurve = V.require("WorldCurve")
 local ViewBox = V.require("ViewBox")
 local OverworldBattle = V.require("OverworldBattle")
+local StadiumBattleFxProvider = V.require("StadiumBattleFxProvider")
 local BattleExit = V.require("BattleExit")
 local Shiny = V.require("Shiny")
 local ShinyBattle = V.require("ShinyBattle")
@@ -139,6 +140,10 @@ function V.dlog(msg)
 end
 V.dlog(("main.lua loading path=%s id=%s"):format(
   tostring(mod.path), tostring(mod.id)))
+
+mod.events:on("mods.loaded", function()
+  StadiumBattleFxProvider.register()
+end)
 
 -- Forward declaration: the voxel pipeline's update hook (registered below)
 -- calls this, and it is defined further down with the settings it drives.

--- a/tests/stadium_battle_fx_provider_test.lua
+++ b/tests/stadium_battle_fx_provider_test.lua
@@ -1,0 +1,75 @@
+-- Standalone contract test for optional StadiumBattleFX arena registration.
+local expectedOwner = "DRAMATIC_SHAPE"
+local fallback = {}
+local registered
+local calls = {}
+local OverworldBattle = {
+  providerAvailable = function(battle)
+    calls.available = battle
+    return battle == "battle"
+  end,
+  arena = function() return { id = "map-arena" } end,
+  providerBegin = function(battle)
+    calls.begin = battle
+    return battle == "battle"
+  end,
+  providerRender = function(battle, drawActors)
+    calls.render = battle
+    drawActors({ vp = {}, groundY = 7, width = 160, height = 144 })
+    return "canvas"
+  end,
+  providerFinish = function() calls.finished = true end,
+}
+local api = {
+  version = 1,
+  FALLBACK = fallback,
+  registerComponent = function(_, owner, slot, id, definition)
+    registered = { owner, slot, id, definition }
+    return owner .. ":" .. id
+  end,
+}
+local V = {
+  mod = {
+    id = expectedOwner,
+    find = function(id)
+      if id == "STADIUM_BATTLE_FX" then
+        return { exports = { battles = api } }
+      end
+    end,
+    log = { warn = function() error("registration should not warn") end },
+  },
+  require = function(name)
+    assert(name == "OverworldBattle")
+    return OverworldBattle
+  end,
+}
+
+for _, path in ipairs({
+  "lib/BattleScene.lua",
+  "lib/OverworldBattle.lua",
+  "lib/StadiumBattleFxProvider.lua",
+  "main.lua",
+}) do
+  assert(loadfile(path), path .. " must compile")
+end
+
+local Provider = assert(loadfile("lib/StadiumBattleFxProvider.lua"))(V)
+assert(Provider.register() == true)
+assert(Provider.register() == true, "registration must be idempotent")
+assert(registered[1] == expectedOwner and registered[2] == "arena"
+  and registered[3] == "voxel-map")
+local definition = registered[4]
+assert(definition.available({ battle = "battle" }) == true)
+assert(definition.available({ battle = "other" }) == false)
+assert(definition.provider == Provider)
+assert(Provider:arena({ battle = "other" }) == fallback)
+assert(Provider:arena({ battle = "battle" }).id == "map-arena")
+assert(Provider:begin({ battle = "battle" }) == true)
+local drew
+assert(Provider:render({ battle = "battle" }, {}, function(world)
+  drew = world.groundY == 7 and world.width == 160 and world.height == 144
+end) == "canvas")
+assert(drew == true and calls.render == "battle")
+Provider:finish()
+assert(calls.finished == true)
+print("ok StadiumBattleFX voxel-map arena provider " .. expectedOwner)


### PR DESCRIPTION
## What changed

Adds an optional StadiumBattleFX Battle Presentation API v1 arena provider for Dramatic Shape 1.8.2.

When the player selects **DRAMATIC SHAPE VOXEL MAP** under SBFX's **BTL ARENA**, Dramatic Shape renders its staged map environment and invokes `drawActors(world)` inside the live depth pass. Its bundled cards and Stadium actors are omitted only while the API host supplies independently selected actors. Legacy Stadium-disc stages deliberately decline this map-arena provider.

## Compatibility impact

The purpose of this patch is compatibility with other battle-presentation mods through explicit component selection:

- Dramatic Shape contributes only its voxel-map arena.
- Stadium 1, Stadium 2, another compatible model provider, or OFF can be selected independently under **BTL MODELS**.
- Effects, camera, HUD, announcer, overlays, and transitions remain independently selectable.
- No provider is selected by load order.
- StadiumBattleFX is optional; without it, Dramatic Shape's existing standalone behavior is unchanged.
- Unsupported encounters and disc stages safely fall back through the public API.

## Validation

- Added a standalone provider registration/lifecycle contract test.
- Verified changed Lua files compile under LÖVE.
- Existing ROM-content lint reports three pre-existing `tools/*shiny*` cache references; this patch does not touch those tools or add ROM-derived content.