### PR TITLE
chore: point github/contact at scottcandy34 fork

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
   ],
   "affects_link": false,
   "description": "Draws the overworld as a 3D diorama.",
-  "github": "DramaticShape/DramaticShapeVoxelMod"
+  "github": "scottcandy34/DramaticShapeVoxelMod-latest"
 }

--- a/mod.card
+++ b/mod.card
@@ -3,7 +3,7 @@
 return {
   summary = "The overworld as a 3D diorama, and battles fought on it: real occlusion, tilt-shift, over-the-shoulder fights.",
   author = "DramaticShape",
-  contact = "https://github.com/DramaticShape/DRAMATIC_SHAPE",
+  contact = "https://github.com/scottcandy34/DramaticShapeVoxelMod-latest",
   tags = { "graphics", "3d", "voxel", "render-pipeline", "presentation",
            "battle" },
   differences = {


### PR DESCRIPTION
Update packaging metadata so the maintained fork is the advertised source.

- manifest.json: github → scottcandy34/DramaticShapeVoxelMod-latest
- mod.card: contact URL → the same repo

Author credit for DramaticShape is unchanged.
