### PR TITLE
fix: sandbox-safe love.system/filesystem and Game mouse wraps

### DIFF
--- a/lib/CamControl.lua
+++ b/lib/CamControl.lua
@@ -262,8 +262,10 @@ function CamControl.install()
     return math.max(-MOUSE_STEP, math.min(MOUSE_STEP, v or 0))
   end
   do
-    local inner = love.mousemoved
-    love.mousemoved = function(x, y, dx, dy, istouch)
+    -- Assigning love.mousemoved is blocked by the mod sandbox; wrap the
+    -- Game method that main.lua routes the love callback into instead.
+    local inner = Game.mousemoved
+    function Game:mousemoved(x, y, dx, dy, istouch)
       if battleLive() and not istouch then
         -- dy is NEGATED for the same reason the stick's is: moving the
         -- mouse away from you sends the camera up and over
@@ -272,7 +274,7 @@ function CamControl.install()
         -- forwarded anyway: the cursor still has UI to point at, and the
         -- steer is a read of the motion rather than a claim on it
       end
-      if inner then return inner(x, y, dx, dy, istouch) end
+      if inner then return inner(self, x, y, dx, dy, istouch) end
     end
   end
 

--- a/lib/CatchThrow.lua
+++ b/lib/CatchThrow.lua
@@ -1338,35 +1338,37 @@ function CatchThrow.installInput()
   -- these are the OUTER ones and the aim owns the button first. Bare
   -- motion is not claimed -- CamControl's battle steer already stands
   -- down while the capture holds the camera (BattleCam.steerable).
+  -- Assigning love.* callbacks is blocked by the mod sandbox; wrap the
+  -- Game methods that main.lua routes those callbacks into instead.
   do
-    local inner = love.mousepressed
-    love.mousepressed = function(x, y, button, istouch, presses)
+    local inner = Game.mousepressed
+    function Game:mousepressed(x, y, button, istouch, presses)
       if aiming() and not istouch and button == 1 then
         pointer("press", x, y, "mouse")
         return
       end
-      if inner then return inner(x, y, button, istouch, presses) end
+      if inner then return inner(self, x, y, button, istouch, presses) end
     end
   end
   do
-    local inner = love.mousemoved
-    love.mousemoved = function(x, y, dx, dy, istouch)
+    local inner = Game.mousemoved
+    function Game:mousemoved(x, y, dx, dy, istouch)
       if aiming() and not istouch and S.grab and S.grab.id == "mouse" then
         pointer("move", x, y, "mouse")
         return
       end
-      if inner then return inner(x, y, dx, dy, istouch) end
+      if inner then return inner(self, x, y, dx, dy, istouch) end
     end
   end
   do
-    local inner = love.mousereleased
-    love.mousereleased = function(x, y, button, istouch, presses)
+    local inner = Game.mousereleased
+    function Game:mousereleased(x, y, button, istouch, presses)
       if aiming() and not istouch and button == 1
          and S.grab and S.grab.id == "mouse" then
         pointer("release", x, y, "mouse")
         return
       end
-      if inner then return inner(x, y, button, istouch, presses) end
+      if inner then return inner(self, x, y, button, istouch, presses) end
     end
   end
 

--- a/lib/FirstPerson.lua
+++ b/lib/FirstPerson.lua
@@ -674,13 +674,13 @@ end
 
 -- ------- input capture
 --
--- The seams: relative mouse motion has no Game handler at all (the
--- engine's love.mousemoved only feeds the mouse-as-touch debug path), the
--- right stick's axes are explicitly ignored by Input, and a touch
--- anywhere off the overlay's controls dies in TouchControls. Each wrap
--- forwards everything it does not claim, and claims only while first
--- person is actually driving -- so with the rung off, every byte flows
--- exactly where it always did.
+-- The seams: relative mouse motion is taken by wrapping Game:mousemoved
+-- (main.lua routes love.mousemoved into it), the right stick's axes are
+-- explicitly ignored by Input, and a touch anywhere off the overlay's
+-- controls dies in TouchControls. Each wrap forwards everything it does
+-- not claim, and claims only while first person is actually driving --
+-- so with the rung off, every byte flows exactly where it always did.
+-- Assigning love.* callbacks is blocked by the mod sandbox.
 
 local installed = false
 
@@ -740,19 +740,20 @@ function FirstPerson.install()
 
   -- ------- mouse
   --
-  -- love.mousemoved rather than a Game method, because the engine has no
-  -- Game:mousemoved to wrap -- the callback in the project's main.lua is
-  -- the one place relative counts arrive. Claimed only while captured;
-  -- pass-through otherwise, including the mouse-as-touch path.
+  -- Wrap Game:mousemoved / mousepressed / mousereleased (the engine now
+  -- has these methods and main.lua routes the love callbacks into them).
+  -- Assigning love.mousemoved etc. is blocked by the mod sandbox.
+  -- Claimed only while captured; pass-through otherwise, including the
+  -- mouse-as-touch path.
   do
-    local inner = love.mousemoved
-    love.mousemoved = function(x, y, dx, dy, istouch)
+    local inner = Game.mousemoved
+    function Game:mousemoved(x, y, dx, dy, istouch)
       if captured and not istouch then
         mouseDX = mouseDX + (dx or 0)
         mouseDY = mouseDY + (dy or 0)
         return
       end
-      if inner then return inner(x, y, dx, dy, istouch) end
+      if inner then return inner(self, x, y, dx, dy, istouch) end
     end
   end
   -- While the mouse is captured there is no cursor to click UI with, so
@@ -782,8 +783,8 @@ function FirstPerson.install()
     return false
   end
   do
-    local inner = love.mousepressed
-    love.mousepressed = function(x, y, button, istouch, presses)
+    local inner = Game.mousepressed
+    function Game:mousepressed(x, y, button, istouch, presses)
       if captured and not istouch and hordeMouse(button, true) then return end
       if captured and not istouch and MOUSE_BTN[button] then
         local Input = require("src.core.Input")
@@ -791,12 +792,12 @@ function FirstPerson.install()
         Input:overlayPressed(MOUSE_BTN[button])
         return
       end
-      if inner then return inner(x, y, button, istouch, presses) end
+      if inner then return inner(self, x, y, button, istouch, presses) end
     end
   end
   do
-    local inner = love.mousereleased
-    love.mousereleased = function(x, y, button, istouch, presses)
+    local inner = Game.mousereleased
+    function Game:mousereleased(x, y, button, istouch, presses)
       -- a release always reaches whoever owns the press: the horde's
       -- aim-hold has to let go even if the mode ended mid-click
       if not mouseHeld[button] and hordeMouse(button, false) then return end
@@ -806,7 +807,7 @@ function FirstPerson.install()
         Input:overlayReleased(MOUSE_BTN[button])
         return
       end
-      if inner then return inner(x, y, button, istouch, presses) end
+      if inner then return inner(self, x, y, button, istouch, presses) end
     end
   end
 

--- a/lib/ForestAtmos.lua
+++ b/lib/ForestAtmos.lua
@@ -84,8 +84,12 @@ end
 -- ModSetting's unknown-value fallback lands it on LOW, and putting the
 -- save back on the desktop restores the choice.
 local function onAndroid()
-  if not (love and love.system and love.system.getOS) then return false end
-  local ok, os = pcall(love.system.getOS)
+  -- love.system is sandboxed away from mods (gen1recomp sandbox). Accessing
+  -- it raises; the pcall below catches that so we treat the platform as
+  -- unknown and fall back to the full ladder. ModSetting's unknown-value
+  -- path still maps a stored FULL to LOW on phones, and FULL is a no-op
+  -- on Android (no readable depth texture).
+  local ok, os = pcall(function() return love.system.getOS() end)
   return ok and os == "Android"
 end
 

--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -435,7 +435,10 @@ end
 local session = nil
 
 local function isIOS()
-  return love.system and love.system.getOS and love.system.getOS() == "iOS"
+  -- love.system is sandboxed away from mods; pcall so a blocked access is
+  -- treated as "not iOS" rather than raising.
+  local ok, os = pcall(function() return love.system.getOS() end)
+  return ok and os == "iOS"
 end
 
 local function game()

--- a/lib/Perf.lua
+++ b/lib/Perf.lua
@@ -41,10 +41,11 @@ local function envFlag(name)
 end
 
 local function flagFile()
-  if not (love and love.filesystem and love.filesystem.getInfo) then
-    return false
-  end
-  local ok, info = pcall(love.filesystem.getInfo, "ds_perf.flag")
+  -- love.filesystem is sandboxed away from mods. Probe via pcall so a
+  -- blocked access is treated as "no flag file" rather than raising.
+  local ok, info = pcall(function()
+    return love.filesystem.getInfo("ds_perf.flag")
+  end)
   return ok and info ~= nil
 end
 
@@ -315,20 +316,18 @@ function Perf.toJson(meta)
   return table.concat(parts, "")
 end
 
--- Written through love.filesystem (the save directory) rather than io:
--- a driver run and an Android session both have one, and neither is
--- guaranteed a writable working directory.
+-- Written through love.filesystem when the sandbox still allows it; otherwise
+-- fall through to print. love.filesystem is blocked for mods in current
+-- gen1recomp, so the pcall path is the safe one.
 function Perf.write(name, meta)
   local body = Perf.toJson(meta)
-  if love and love.filesystem then
-    pcall(love.filesystem.createDirectory, "ds_bench")
-    local ok = pcall(love.filesystem.write, "ds_bench/" .. name .. ".json", body)
-    if ok then
-      print("[perf] wrote " .. tostring(love.filesystem.getSaveDirectory())
-            .. "/ds_bench/" .. name .. ".json")
-      return true
-    end
-  end
+  local ok = pcall(function()
+    love.filesystem.createDirectory("ds_bench")
+    love.filesystem.write("ds_bench/" .. name .. ".json", body)
+    print("[perf] wrote " .. tostring(love.filesystem.getSaveDirectory())
+          .. "/ds_bench/" .. name .. ".json")
+  end)
+  if ok then return true end
   print("[perf] JSON " .. name .. ": " .. body)
   return false
 end

--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -238,8 +238,11 @@ end
 -- where nothing stands in (see lib/Shadows).
 function ShadowMap.available()
   if not ShadowMap.wanted() then return false end
-  if love.system and love.system.getOS and love.system.getOS() == "iOS" then
-    return false
+  -- love.system is sandboxed away from mods; probe via pcall. On iOS the
+  -- depth/canvas path is known-bad, so stay off. Unknown platform continues.
+  do
+    local ok, os = pcall(function() return love.system.getOS() end)
+    if ok and os == "iOS" then return false end
   end
   if not (love.graphics and love.graphics.newCanvas
           and love.graphics.setDepthMode) then

--- a/lib/StadiumInstall.lua
+++ b/lib/StadiumInstall.lua
@@ -88,7 +88,10 @@ local NAMED = {
 }
 
 local function fs()
-  return love and love.filesystem
+  -- love.filesystem is sandboxed away from mods. Return nil when blocked
+  -- so callers treat the filesystem as unavailable rather than raising.
+  local ok, f = pcall(function() return love.filesystem end)
+  return (ok and f) or nil
 end
 
 local function isFile(path)

--- a/lib/StadiumRomPick.lua
+++ b/lib/StadiumRomPick.lua
@@ -284,8 +284,10 @@ end
 -- would be imported again on the next boot, and kept forever if the import
 -- failed.
 function StadiumRomPick.poll(game)
-  local f = love and love.filesystem
-  if not (f and f.getInfo) then return false end
+  -- love.filesystem is sandboxed away from mods; pcall so a blocked access
+  -- is treated as "no native pick pending" rather than raising.
+  local okFs, f = pcall(function() return love.filesystem end)
+  if not (okFs and f and f.getInfo) then return false end
   if StadiumInstall.status.state == "building" then return false end
   local ok, info = pcall(f.getInfo, StadiumRomPick.PICKED, "file")
   if not (ok and info) then return false end


### PR DESCRIPTION
Adapt the mod to gen1recomp’s mod sandbox, which blocks love.system,
love.filesystem, and assignment to love.* callbacks.

- ForestAtmos, ShadowMap, OverworldBattle: probe OS via pcall instead of
  bare love.system access (ShadowMap was aborting the voxel draw path).
- FirstPerson, CamControl, CatchThrow: wrap Game:mousemoved /
  mousepressed / mousereleased instead of assigning love.* handlers.
- Perf, StadiumInstall, StadiumRomPick: guard love.filesystem with pcall
  so blocked access fails soft instead of raising.

Restores mod load, voxel rendering, and first-person / battle / catch
mouse input on current gen1recomp builds.
