### PR TITLE
feat: unified mod.storage diagnostic log (gen2 sites + legacy prints)

### DIFF
--- a/lib/CamControl.lua
+++ b/lib/CamControl.lua
@@ -412,6 +412,7 @@ function CamControl.install()
       return inner(self, f)
     end
   end
+  if V.log then V.log:event("input", "CamControl.install", { ok = "true" }) end
 end
 
 return CamControl

--- a/lib/CatchThrow.lua
+++ b/lib/CatchThrow.lua
@@ -844,6 +844,12 @@ end
 function CatchThrow.cancel(declined)
   if not (S and S.phase == "aim") then return false end
   local b = S.battle
+  if V.log then
+    V.log:event("catch", "cancel", {
+      declined = declined and "true" or "false",
+      fullWild = S.fullWild and "true" or "false",
+    })
+  end
   if S.fullWild then
     sound("Run")
     b:say(require("src.core.Strings")("Got away safely!"))
@@ -1155,6 +1161,9 @@ function CatchThrow.begin(battle, ballId, opts)
   end)
   if not ok or not S then
     S = nil
+    if V.log then
+      V.log:warn("CatchThrow.begin failed ball=%s", tostring(ballId))
+    end
     return false
   end
   battle.phase = CatchThrow.PHASE
@@ -1164,6 +1173,13 @@ function CatchThrow.begin(battle, ballId, opts)
   -- closes every input that could move it. The player's own steered angle
   -- and lens come back when the hold releases.
   installScene()
+  if V.log then
+    V.log:event("catch", "begin", {
+      ball = ballId or "empty",
+      safari = opts.safari and "true" or "false",
+      fullWild = opts.fullWild and "true" or "false",
+    })
+  end
   return true
 end
 
@@ -1318,6 +1334,7 @@ end
 function CatchThrow.installInput()
   if installed then return end
   installed = true
+  if V.log then V.log:event("input", "CatchThrow.installInput", { ok = "true" }) end
 
   local Game = require("src.core.Game")
 

--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -1052,8 +1052,14 @@ local function finishJob(job, ok, err)
   end
   if not ok then
     -- name the reason: in a real session a lost build is a black map
-    print("[warn] voxel mesh build failed for " .. tostring(job.id)
-          .. ": " .. tostring(err))
+    local msg = "[warn] voxel mesh build failed for " .. tostring(job.id)
+                .. ": " .. tostring(err)
+    print(msg)
+    if V and V.dlog then V.dlog(msg) end
+    if V and V.log then
+      V.log:error("async mesh build failed map=%s: %s",
+        tostring(job.id), tostring(err))
+    end
     if (gen[job.id] or 0) == job.gen then
       entry(job.id)[job.slot] = false
     end
@@ -1201,8 +1207,14 @@ function ChunkMesher.get(map, bodyOnly, masks)
     local ok, mesh, water = pcall(ChunkMesher.build, map, bodyOnly, masks,
                                   true)
     if not ok then
-      print("[warn] voxel mesh build failed for " .. tostring(map.id)
-            .. ": " .. tostring(mesh))
+      local msg = "[warn] voxel mesh build failed for " .. tostring(map.id)
+                  .. ": " .. tostring(mesh)
+      print(msg)
+      if V and V.dlog then V.dlog(msg) end
+      if V.log then
+        V.log:error("mesh build failed map=%s slot=%s: %s",
+          tostring(map.id), tostring(slot), tostring(mesh))
+      end
     end
     swapSlot(c, slot, (ok and mesh) or false)
     swapSlot(c, waterSlot(slot), (ok and water) or false)

--- a/lib/FirstPerson.lua
+++ b/lib/FirstPerson.lua
@@ -472,6 +472,9 @@ function FirstPerson.update(dt)
     end)
     FirstPerson.yaw = (ok and FACING_ANGLE[facing]) or 0
     FirstPerson.pitch = FirstPerson.PITCH_DEFAULT
+    if V.log then V.log:event("camera", "firstperson-enter", { facing = facing or "unknown" }) end
+  elseif wasEngaged and not engagedNow then
+    if V.log then V.log:event("camera", "firstperson-leave", {}) end
   end
   wasEngaged = engagedNow
 

--- a/lib/ForestAtmos.lua
+++ b/lib/ForestAtmos.lua
@@ -154,7 +154,10 @@ local said = {}
 local function say(key, msg)
   if said[key] then return end
   said[key] = true
-  print("[DRAMATIC_SHAPE] atmos: " .. msg)
+  msg = "atmos: " .. tostring(msg)
+  if V and V.dlog then V.dlog(msg)
+  elseif V and V.log then V.log:info("%s", msg)
+  else print("[DRAMATIC_SHAPE] " .. msg) end
 end
 
 function ForestAtmos.invalidate(mapId)

--- a/lib/FreeMove.lua
+++ b/lib/FreeMove.lua
@@ -382,6 +382,7 @@ function FreeMove.install()
   end
 
   OverworldState.dramaticShapeFreeMoveHook = true
+  if V.log then V.log:event("input", "FreeMove.install", { ok = "true" }) end
 end
 
 return FreeMove

--- a/lib/HordeSfx.lua
+++ b/lib/HordeSfx.lua
@@ -189,8 +189,12 @@ function HordeSfx.register(mod)
         mod.content.sfx:register(name, { chip = out.chip })
       end)
       if reg then n = n + 1 end
-    elseif mod.log then
-      mod.log:error("horde: sfx %s did not assemble: %s", name, tostring(out))
+    else
+      local msg = ("horde: sfx %s did not assemble: %s"):format(
+        tostring(name), tostring(out))
+      if V.log then V.log:error("%s", msg)
+      elseif V.dlog then V.dlog(msg)
+      elseif V.mod and V.mod.log then V.mod.log:error("%s", msg) end
     end
   end
   return n > 0

--- a/lib/ModLog.lua
+++ b/lib/ModLog.lua
@@ -1,0 +1,127 @@
+-- Persistent, player-exportable diagnostics for Dramatic Shape.
+-- Entries are event-based (no per-frame spam). Survives across boots via
+-- mod.storage under the key diagnostics/log.
+
+local V = ...
+local Storage = V.require("ModStorage")
+local Log = {}
+Log.__index = Log
+
+local MAX_LINES = 1500
+
+local function clean(value)
+  return tostring(value or "nil"):gsub("[\r\n\t]+", " "):gsub("%s+", " ")
+end
+
+local function now()
+  if os and os.date then return os.date("!%Y-%m-%dT%H:%M:%SZ") end
+  return "runtime"
+end
+
+local function format(message, ...)
+  if select("#", ...) == 0 then return clean(message) end
+  local ok, value = pcall(string.format, tostring(message), ...)
+  return clean(ok and value or message)
+end
+
+function Log.new(host)
+  local self = setmetatable({ host = host, lines = {} }, Log)
+  local ver = (V.mod and V.mod.manifest and V.mod.manifest.version)
+    or (V.mod and V.mod.version) or "unknown"
+  self:info("session started; Dramatic Shape %s", tostring(ver))
+  self:event("runtime", "environment", {
+    api = (V.mod and V.mod.manifest and V.mod.manifest.api) or "unknown",
+    id = (V.mod and V.mod.id) or "DRAMATIC_SHAPE",
+  })
+  return self
+end
+
+function Log:loadStored()
+  if self.loaded then return self.loaded end
+  if not Storage.game() then return false end
+  local record = Storage.read("diagnostics/log")
+  if type(record) == "table" and type(record.lines) == "table" then
+    local current = self.lines
+    self.lines = {}
+    for _, line in ipairs(record.lines) do
+      if type(line) == "string" then self.lines[#self.lines + 1] = line end
+    end
+    for _, line in ipairs(current) do self.lines[#self.lines + 1] = line end
+  end
+  self.loaded = true
+  return true
+end
+
+function Log:flush()
+  -- Bind whatever game we can see, then persist.
+  if not Storage.game() then
+    local ok, Game = pcall(require, "src.core.Game")
+    if ok and Game then Storage.setGame(Game) end
+  end
+  if not self:loadStored() and not Storage.game() then
+    return false, "storage_unavailable", "No active playthrough for mod storage."
+  end
+  local ok, code, message = Storage.write("diagnostics/log", {
+    format = 1,
+    lines = self.lines,
+    updated = now(),
+  })
+  return ok, code, message
+end
+
+function Log:record(level, message, ...)
+  self:loadStored()
+  local line = ("%s [%s] %s"):format(now(), level, format(message, ...))
+  self.lines[#self.lines + 1] = line
+  while #self.lines > MAX_LINES do table.remove(self.lines, 1) end
+  -- Best-effort persist; never raise from logging.
+  pcall(function() self:flush() end)
+  local fn = self.host and self.host[level:lower()]
+  if type(fn) == "function" then pcall(fn, self.host, "%s", line) end
+  return line
+end
+
+function Log:info(message, ...) return self:record("INFO", message, ...) end
+function Log:warn(message, ...) return self:record("WARN", message, ...) end
+function Log:error(message, ...) return self:record("ERROR", message, ...) end
+
+-- Structured line for cross-mod / LLM-friendly diagnostics.
+function Log:event(scope, name, fields)
+  local parts = {}
+  for key, value in pairs(type(fields) == "table" and fields or {}) do
+    parts[#parts + 1] = clean(key) .. "=" .. clean(value)
+  end
+  table.sort(parts)
+  local suffix = #parts > 0 and (" " .. table.concat(parts, " ")) or ""
+  return self:info("[%s] %s%s", clean(scope), clean(name), suffix)
+end
+
+function Log:scope(scope)
+  local parent = self
+  return {
+    info = function(_, message, ...)
+      return parent:info("[%s] " .. message, scope, ...)
+    end,
+    warn = function(_, message, ...)
+      return parent:warn("[%s] " .. message, scope, ...)
+    end,
+    error = function(_, message, ...)
+      return parent:error("[%s] " .. message, scope, ...)
+    end,
+    event = function(_, name, fields)
+      return parent:event(scope, name, fields)
+    end,
+  }
+end
+
+function Log:contents()
+  return table.concat(self.lines, "\n") .. "\n"
+end
+
+function Log:clear()
+  self.lines = {}
+  self.loaded = true
+  return self:flush()
+end
+
+return Log

--- a/lib/ModLogExport.lua
+++ b/lib/ModLogExport.lua
@@ -1,0 +1,48 @@
+-- Options-row action: force-flush the diagnostic log to mod.storage.
+-- The log is also always available via mod.exports.diagnosticLog().
+
+local V = ...
+local Export = {}
+local last = { state = "SAVE", message = nil }
+
+local function result(state, message)
+  last = { state = state, message = message }
+  return state == "SAVED", message
+end
+
+function Export.available()
+  return V.mod and V.mod.storage ~= nil
+end
+
+function Export.status()
+  return last.state, last.message
+end
+
+function Export.export()
+  if not Export.available() then
+    return result("UNAVAILABLE", "Mod storage is unavailable.")
+  end
+  local log = V.log
+  if not log or not log.flush then
+    return result("FAILED", "Diagnostic log is not initialised.")
+  end
+  local ok, code, message = log:flush()
+  if not ok then
+    return result("FAILED", tostring(message or code or "Could not save diagnostics."))
+  end
+  return result("SAVED", "Diagnostic snapshot saved for this playthrough.")
+end
+
+function Export.row()
+  return {
+    id = "DRAMATIC_SHAPE:exportLog",
+    label = "SAVE DIAGNOSTIC SNAPSHOT",
+    value = function()
+      if not Export.available() then return "UNAVAILABLE" end
+      return last.state
+    end,
+    step = function() return Export.export() end,
+  }
+end
+
+return Export

--- a/lib/ModStorage.lua
+++ b/lib/ModStorage.lua
@@ -1,0 +1,53 @@
+-- Sandbox-safe access to this mod's playthrough storage.
+-- Runtime modules use logical keys only; the engine owns every real path.
+-- Mirrors the pattern used by StadiumBattleFX (anxiousintrovert).
+
+local V = ...
+local Storage = {}
+local currentGame
+local fallback = {}
+
+function Storage.setGame(game)
+  if game then currentGame = game end
+  return currentGame
+end
+
+function Storage.game()
+  if currentGame then return currentGame end
+  local ok, game = pcall(function() return V.mod.game end)
+  if ok then return game end
+end
+
+function Storage.active()
+  return V.mod and V.mod.storage ~= nil and Storage.game() ~= nil
+end
+
+function Storage.read(key)
+  local api, game = V.mod and V.mod.storage, Storage.game()
+  if api and api.read and game then
+    local value, code, message = api:read(game, key)
+    if value ~= nil then return value end
+    return nil, code, message
+  end
+  local value = fallback[key]
+  if value ~= nil then return value end
+  return nil, "storage_unavailable",
+    "Mod storage needs an active playthrough."
+end
+
+function Storage.write(key, value)
+  local api, game = V.mod and V.mod.storage, Storage.game()
+  if api and api.write and game then return api:write(game, key, value) end
+  -- In-memory fallback for early boot / headless before a game is bound.
+  fallback[key] = value
+  return true
+end
+
+function Storage.delete(key)
+  local api, game = V.mod and V.mod.storage, Storage.game()
+  if api and api.delete and game then return api:delete(game, key) end
+  fallback[key] = nil
+  return true
+end
+
+return Storage

--- a/lib/OverworldBattle.lua
+++ b/lib/OverworldBattle.lua
@@ -570,7 +570,14 @@ function OverworldBattle.ensure(battle)
   end
   local g = game()
   local ow = g and g.overworld
-  if ow and ow.map then OverworldBattle.begin(ow, battle) end
+  if ow and ow.map then
+    OverworldBattle.begin(ow, battle)
+    if V.log then
+      V.log:event("owbattle", "ensure", {
+        map = ow.map and ow.map.id or "unknown",
+      })
+    end
+  end
 end
 
 -- The arena this battle is staged on, or nil. Read by the shot driver so a
@@ -585,6 +592,7 @@ function OverworldBattle.finish()
   session = nil
   Voxel3D.camera = nil
   pcall(function() V.require("Stadium").finish() end)
+  if V.log then V.log:event("owbattle", "finish", {}) end
 end
 
 -- ------- per-frame
@@ -692,8 +700,11 @@ function OverworldBattle.update(dt)
     session.shot = nil
     session.snapped = false
     session.broken = true
-    V.mod.log:warn("overworld battle scene failed: %s -- this battle draws "
-                   .. "on the plain battle background", tostring(shot))
+    local msg = ("overworld battle scene failed: %s -- this battle draws "
+                 .. "on the plain battle background"):format(tostring(shot))
+    if V.log then V.log:warn("%s", msg)
+    elseif V.dlog then V.dlog(msg)
+    elseif V.mod and V.mod.log then V.mod.log:warn("%s", msg) end
     return
   end
   session.snapped = false
@@ -722,8 +733,11 @@ function OverworldBattle.update(dt)
     -- do it sixty times a second either, and the fallback is silent and fine
     if not okHud and not session.hudWarned then
       session.hudWarned = true
-      V.mod.log:warn("overworld battle HUD snap failed: %s -- the HUDs draw "
-                     .. "in the battle frame this battle", tostring(up))
+      local msg = ("overworld battle HUD snap failed: %s -- the HUDs draw "
+                   .. "in the battle frame this battle"):format(tostring(up))
+      if V.log then V.log:warn("%s", msg)
+      elseif V.dlog then V.dlog(msg)
+      elseif V.mod and V.mod.log then V.mod.log:warn("%s", msg) end
     end
   end
   session.shot = shot

--- a/lib/Perf.lua
+++ b/lib/Perf.lua
@@ -26,9 +26,18 @@
 -- GPU-side saving shows up in the FRAME numbers rather than in the label
 -- for the pass that caused it, and both are reported.
 
+local V = ...
 local Perf = {}
 
 local clock = (love and love.timer and love.timer.getTime) or os.clock
+
+-- Route perf lines into the mod diagnostic log when available.
+local function emit(msg)
+  msg = tostring(msg)
+  print(msg)
+  if V and V.dlog then V.dlog(msg)
+  elseif V and V.log then V.log:info("%s", msg) end
+end
 
 -- Read through pcall: the loader's sandbox does not hand a mod `os`, and
 -- instrumentation must never be the reason the mod fails to load. Same
@@ -230,27 +239,27 @@ local function sortedLabels(store, order)
 end
 
 function Perf.printReport(title)
-  print(("[perf] ==== %s ===="):format(tostring(title or "report")))
+  emit(("[perf] ==== %s ===="):format(tostring(title or "report")))
   local f = Perf.frameStats()
-  print(("[perf] frames n=%d avg=%.2fms p50=%.2f p95=%.2f p99=%.2f worst=%.2f  >16.7ms=%d  >33.3ms=%d")
+  emit(("[perf] frames n=%d avg=%.2fms p50=%.2f p95=%.2f p99=%.2f worst=%.2f  >16.7ms=%d  >33.3ms=%d")
     :format(f.n, f.avg, f.p50, f.p95, f.p99, f.worst, f.over16, f.over33))
   for _, seg in ipairs(Perf.segments) do
     local s = Perf.frameStats(seg.frames)
-    print(("[perf] seg %-28s n=%4d avg=%6.2f p95=%6.2f p99=%6.2f worst=%7.2f >16.7=%3d >33.3=%3d")
+    emit(("[perf] seg %-28s n=%4d avg=%6.2f p95=%6.2f p99=%6.2f worst=%7.2f >16.7=%3d >33.3=%3d")
       :format(seg.name, s.n, s.avg, s.p95, s.p99, s.worst, s.over16, s.over33))
   end
-  print("[perf] ---- labels (ms, sorted by total) ----")
+  emit("[perf] ---- labels (ms, sorted by total) ----")
   for _, lbl in ipairs(sortedLabels(Perf.labels, Perf.order)) do
     local s = Perf.labels[lbl]
-    print(("[perf] %-46s n=%6d total=%9.1f max=%8.2f")
+    emit(("[perf] %-46s n=%6d total=%9.1f max=%8.2f")
       :format(lbl, s.n, s.total * 1000, s.max * 1000))
   end
   local names = {}
   for k in pairs(Perf.counters) do names[#names + 1] = k end
   table.sort(names)
-  if #names > 0 then print("[perf] ---- counters ----") end
+  if #names > 0 then emit("[perf] ---- counters ----") end
   for _, k in ipairs(names) do
-    print(("[perf] %-46s %d"):format(k, Perf.counters[k]))
+    emit(("[perf] %-46s %d"):format(k, Perf.counters[k]))
   end
 end
 
@@ -324,11 +333,11 @@ function Perf.write(name, meta)
   local ok = pcall(function()
     love.filesystem.createDirectory("ds_bench")
     love.filesystem.write("ds_bench/" .. name .. ".json", body)
-    print("[perf] wrote " .. tostring(love.filesystem.getSaveDirectory())
+    emit("[perf] wrote " .. tostring(love.filesystem.getSaveDirectory())
           .. "/ds_bench/" .. name .. ".json")
   end)
   if ok then return true end
-  print("[perf] JSON " .. name .. ": " .. body)
+  emit("[perf] JSON " .. name .. ": " .. body)
   return false
 end
 

--- a/lib/ShadowMap.lua
+++ b/lib/ShadowMap.lua
@@ -242,15 +242,30 @@ function ShadowMap.available()
   -- depth/canvas path is known-bad, so stay off. Unknown platform continues.
   do
     local ok, os = pcall(function() return love.system.getOS() end)
-    if ok and os == "iOS" then return false end
+    if ok and os == "iOS" then
+      if V.log and not V._shadowIos then
+        V._shadowIos = true
+        V.log:event("shadowmap", "unavailable", { reason = "ios" })
+      end
+      return false
+    end
   end
   if not (love.graphics and love.graphics.newCanvas
           and love.graphics.setDepthMode) then
+    if V.log and not V._shadowGfx then
+      V._shadowGfx = true
+      V.log:event("shadowmap", "unavailable", { reason = "no-depth-canvas" })
+    end
     return false
   end
   -- the smallest rung is enough to answer the question; fit() picks the
   -- one this frame actually wants
-  return getShader() ~= nil and getCanvas(ShadowMap.SIZES[1]) ~= nil
+  local ok = getShader() ~= nil and getCanvas(ShadowMap.SIZES[1]) ~= nil
+  if not ok and V.log and not V._shadowRes then
+    V._shadowRes = true
+    V.log:event("shadowmap", "unavailable", { reason = "shader-or-canvas" })
+  end
+  return ok
 end
 
 -- The map to sample, or the blank stand-in. Never nil once the main pass

--- a/lib/Sky.lua
+++ b/lib/Sky.lua
@@ -368,12 +368,15 @@ local function getShader()
       local ok, sh = pcall(love.graphics.newShader, SHADER_SRC)
       if ok and sh then
         shader = sh
-      elseif V and V.mod and V.mod.log then
+      else
         -- once, and only where it can be read: the fallback below is a sky
         -- without its dither, which is easy to look at and impossible to
         -- diagnose without this line
-        V.mod.log:warn("sky shader did not compile: %s -- the bands draw flat, "
-                       .. "with no dither between them", tostring(sh))
+        local msg = ("sky shader did not compile: %s -- the bands draw flat, "
+                     .. "with no dither between them"):format(tostring(sh))
+        if V and V.log then V.log:warn("%s", msg)
+        elseif V and V.dlog then V.dlog(msg)
+        elseif V and V.mod and V.mod.log then V.mod.log:warn("%s", msg) end
       end
     end
   end

--- a/lib/StadiumInstall.lua
+++ b/lib/StadiumInstall.lua
@@ -269,8 +269,12 @@ local function writePack(species, bytes, shinyBytes)
     -- its model. Left unwritten, the runtime shows the normal one.
     local sok, serr = f.write(
       ("%s/%03ds.dsm"):format(StadiumInstall.DIR, species), shinyBytes)
-    if not sok and V.mod and V.mod.log then
-      V.mod.log.warn("shiny pack %03d not written: %s", species, tostring(serr))
+    if not sok then
+      local msg = ("shiny pack %03d not written: %s"):format(
+        species, tostring(serr))
+      if V.log then V.log:warn("%s", msg)
+      elseif V.dlog then V.dlog(msg)
+      elseif V.mod and V.mod.log then V.mod.log:warn("%s", msg) end
     end
   end
   return true
@@ -280,12 +284,19 @@ end
 -- plus a reason when there is nothing to build from.
 function StadiumInstall.begin()
   local f = fs()
-  if not f then return false, "no filesystem" end
+  if not f then
+    if V.log then V.log:warn("StadiumInstall.begin: no filesystem") end
+    return false, "no filesystem"
+  end
   local path = StadiumInstall.romPath()
-  if not path then return false, "no ROM in " .. StadiumInstall.ROM_DIR end
+  if not path then
+    if V.log then V.log:warn("StadiumInstall.begin: no ROM in %s", StadiumInstall.ROM_DIR) end
+    return false, "no ROM in " .. StadiumInstall.ROM_DIR
+  end
 
   local okRead, bytes = pcall(f.read, path)
   if not (okRead and type(bytes) == "string") then
+    if V.log then V.log:warn("StadiumInstall.begin: could not read %s", tostring(path)) end
     return false, "could not read " .. path
   end
   return StadiumInstall.beginFrom(bytes, path)
@@ -303,13 +314,28 @@ end
 -- `label` is only ever used to say WHICH file a complaint is about.
 function StadiumInstall.beginFrom(bytes, label)
   local f = fs()
-  if not f then return false, "no filesystem" end
-  if type(bytes) ~= "string" or #bytes == 0 then return false, "empty file" end
+  if not f then
+    if V.log then V.log:warn("StadiumInstall.beginFrom: no filesystem") end
+    return false, "no filesystem"
+  end
+  if type(bytes) ~= "string" or #bytes == 0 then
+    if V.log then V.log:warn("StadiumInstall.beginFrom: empty file label=%s", tostring(label)) end
+    return false, "empty file"
+  end
 
   local StadiumRom = V.require("StadiumRom")
   local StadiumBuild = V.require("StadiumBuild")
   local rom, err = StadiumRom.open(bytes)
-  if not rom then return false, tostring(err) end
+  if not rom then
+    if V.log then V.log:error("StadiumRom.open failed: %s", tostring(err)) end
+    return false, tostring(err)
+  end
+  if V.log then
+    V.log:event("stadium", "beginFrom", {
+      label = label or "bytes",
+      size = #bytes,
+    })
+  end
   status.wrongVersion = false
   if not rom:isExpectedUS() then
     -- Built anyway rather than refused: a dump can differ from the reference
@@ -319,11 +345,14 @@ function StadiumInstall.beginFrom(bytes, label)
     -- promised, so it is said loudly, with the md5 that IS expected so the
     -- player can check their own file against it.
     status.wrongVersion = true
-    V.mod.log:warn("stadium: %s is md5 %s -- the model offsets are keyed to "
-                   .. "Pokemon Stadium (US) 1.0, which is md5 %s. Building "
-                   .. "anyway, but the models may be wrong or fail to build.",
-                   tostring(label or "the ROM"), tostring(rom:md5()),
-                   tostring(StadiumRom.US_MD5))
+    local msg = ("stadium: %s is md5 %s -- the model offsets are keyed to "
+                 .. "Pokemon Stadium (US) 1.0, which is md5 %s. Building "
+                 .. "anyway, but the models may be wrong or fail to build."):format(
+      tostring(label or "the ROM"), tostring(rom:md5()),
+      tostring(StadiumRom.US_MD5))
+    if V.log then V.log:warn("%s", msg)
+    elseif V.dlog then V.dlog(msg)
+    elseif V.mod and V.mod.log then V.mod.log:warn("%s", msg) end
   end
 
   -- ------- refuse a ROM with no models in it, BEFORE anything is written

--- a/lib/StadiumScreen.lua
+++ b/lib/StadiumScreen.lua
@@ -373,9 +373,12 @@ function StadiumScreen.maybePush()
       local label = (okPick and pick and pick.LABEL) or "STADIUM ROM"
       local how = (okPick and pick and pick.canDialog())
                   and "opens a file picker" or "says where to put one"
-      V.mod.log:info("stadium: no Pokemon Stadium (US) 1.0 ROM found, so the "
-                     .. "STADIUM battle rungs are off. OPTIONS -> %s %s; the "
-                     .. "folder is %s", label, how, StadiumInstall.romHint())
+      local msg = ("stadium: no Pokemon Stadium (US) 1.0 ROM found, so the "
+                   .. "STADIUM battle rungs are off. OPTIONS -> %s %s; the "
+                   .. "folder is %s"):format(label, how, StadiumInstall.romHint())
+      if V.log then V.log:info("%s", msg)
+      elseif V.dlog then V.dlog(msg)
+      elseif V.mod and V.mod.log then V.mod.log:info("%s", msg) end
     end
     return false
   end

--- a/lib/VR.lua
+++ b/lib/VR.lua
@@ -870,11 +870,17 @@ function VR.update(dt)
     if VRXR.start(qw, qh) then
       started = true
       status = "session created"
-      print("[DRAMATIC_SHAPE] VR: " .. VRXR.status())
+      local msg = "VR: " .. tostring(VRXR.status())
+      if V and V.dlog then V.dlog(msg)
+      elseif V and V.log then V.log:info("%s", msg)
+      else print("[DRAMATIC_SHAPE] " .. msg) end
     else
       failed = VRXR.status()
-      print("[DRAMATIC_SHAPE] VR unavailable: " .. failed
-            .. " -- fix that, then toggle the VR row to retry")
+      local msg = "VR unavailable: " .. tostring(failed)
+                  .. " -- fix that, then toggle the VR row to retry"
+      if V and V.dlog then V.dlog(msg)
+      elseif V and V.log then V.log:warn("%s", msg)
+      else print("[DRAMATIC_SHAPE] " .. msg) end
       return
     end
   end

--- a/lib/Voxel3D.lua
+++ b/lib/Voxel3D.lua
@@ -597,9 +597,18 @@ end
 function Voxel3D.available()
   if not (love.graphics and love.graphics.newCanvas
           and love.graphics.setDepthMode) then
+    if V.log and not V._v3dAvailGfx then
+      V._v3dAvailGfx = true
+      V.log:event("voxel3d", "unavailable", { reason = "no-depth-canvas" })
+    end
     return false
   end
-  return Voxel3D.shader() ~= nil
+  local ok = Voxel3D.shader() ~= nil
+  if not ok and V.log and not V._v3dAvailShader then
+    V._v3dAvailShader = true
+    V.log:event("voxel3d", "unavailable", { reason = "shader-nil" })
+  end
+  return ok
 end
 
 -- Build a mesh in the shared format. `verts` is the LOVE vertex list and

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -913,8 +913,22 @@ function VoxelScene.render(state, w, h, vw, vh, paletteFor, eyes)
   -- return nil: the engine keeps the 2D path for the frame and
   -- Voxel.ready holds the camera tween at flat, so the switch waits
   -- invisibly instead of freezing or tilting an empty stage.
-  local terrain, nbMesh, water, nbWater = VoxelScene.prefetch(state)
-  if not terrain then return nil end
+  local okPrefetch, terrain, nbMesh, water, nbWater = pcall(VoxelScene.prefetch, state)
+  if not okPrefetch then
+    if V.log and not V._scenePrefetchErr then
+      V._scenePrefetchErr = true
+      V.log:error("VoxelScene.prefetch raised: %s", tostring(terrain))
+    end
+    return nil
+  end
+  if not terrain then
+    if V.log and not V._sceneNoTerrain then
+      V._sceneNoTerrain = true
+      local mapId = state and state.map and state.map.id
+      V.log:event("voxelscene", "no-terrain", { map = mapId or "unknown" })
+    end
+    return nil
+  end
 
   local cam = state.camera
   local cx, cy = cam.x + vw / 2, cam.y + vh / 2

--- a/lib/Water.lua
+++ b/lib/Water.lua
@@ -1210,11 +1210,14 @@ function Water.shader(grid)
         local bareOk, bareSh = pcall(love.graphics.newShader, source(grid, true))
         if bareOk then ok, sh = bareOk, bareSh end
       end
-      if not ok and V and V.mod and V.mod.log then
+      if not ok then
         -- once, where it can be read: the fallback is flat water, which is
         -- easy to look at and impossible to diagnose without this line
-        V.mod.log:warn("water shader did not compile: %s -- lakes draw flat",
-                       tostring(sh))
+        local msg = ("water shader did not compile: %s -- lakes draw flat"):format(
+          tostring(sh))
+        if V and V.log then V.log:warn("%s", msg)
+        elseif V and V.dlog then V.dlog(msg)
+        elseif V and V.mod and V.mod.log then V.mod.log:warn("%s", msg) end
       end
       shaders[grid] = (ok and sh) or false
     end

--- a/main.lua
+++ b/main.lua
@@ -119,6 +119,27 @@ local HordeSfx = V.require("HordeSfx")
 local LetsGo = V.require("LetsGo")
 local Pokeball = V.require("Pokeball")
 
+-- ------- diagnostics (mod.storage-backed log)
+--
+-- Same idea as StadiumBattleFX: a ring of event lines persisted under
+-- diagnostics/log in this mod's playthrough storage, exportable via
+-- mod.exports.diagnosticLog() and a SAVE DIAGNOSTIC SNAPSHOT options row.
+local ModStorage = V.require("ModStorage")
+V.storage = ModStorage
+local ModLog = V.require("ModLog")
+V.log = ModLog.new(mod.log)
+local ModLogExport = V.require("ModLogExport")
+
+-- Compatibility bridge used by gen2-gold-beta-style call sites (V.dlog).
+-- Routes into the persistent mod.storage log instead of love.filesystem.
+function V.dlog(msg)
+  msg = tostring(msg)
+  if V.log then V.log:info("%s", msg) end
+  print("[DRAMATIC_SHAPE] " .. msg)
+end
+V.dlog(("main.lua loading path=%s id=%s"):format(
+  tostring(mod.path), tostring(mod.id)))
+
 -- Forward declaration: the voxel pipeline's update hook (registered below)
 -- calls this, and it is defined further down with the settings it drives.
 -- Declared rather than left global -- a mod writing to _G would leak into
@@ -177,7 +198,19 @@ mod.content.render_pipelines:register("voxel", {
   -- answer false here, and the engine keeps the vanilla 2D path -- which
   -- is why no caller ever has to guard for a missing 3D pass.
   available = function()
-    return Voxel3D.available()
+    local ok, avail = pcall(Voxel3D.available)
+    if not ok then
+      if not V._voxelAvailLogged then
+        V._voxelAvailLogged = true
+        V.log:error("Voxel3D.available raised: %s", tostring(avail))
+      end
+      return false
+    end
+    if not V._voxelAvailLogged then
+      V._voxelAvailLogged = true
+      V.log:event("voxel", "available", { ok = avail and "true" or "false" })
+    end
+    return avail and true or false
   end,
 
   -- the engine hands over the live level; we ease the camera toward it.
@@ -191,6 +224,21 @@ mod.content.render_pipelines:register("voxel", {
   -- pump slice -- so stepping out of a door lands on terrain that is
   -- already there instead of a flat flash.
   update = function(dt, level)
+    -- Bind playthrough storage once a Game exists so diagnostics can persist.
+    if not ModStorage.game() then
+      local okG, Game = pcall(require, "src.core.Game")
+      if okG and Game then
+        ModStorage.setGame(Game)
+        V.log:event("runtime", "game-bound", {})
+      end
+    end
+    -- gen2-gold-beta: one-shot first-tick snapshot (level + capability).
+    if not V._updLogged then
+      V._updLogged = true
+      local okA, avail = pcall(function() return Voxel3D.available() end)
+      V.dlog(("voxel update first tick level=%s available=%s"):format(
+        tostring(level), okA and tostring(avail) or tostring(avail)))
+    end
     -- FULL is a preset, so it is applied ON THE PRESS rather than held every
     -- frame: it SETS the other rows and then leaves them alone. Holding them
     -- would make the zoom keys and the wheel dead while the mode was on, and
@@ -220,7 +268,9 @@ mod.content.render_pipelines:register("voxel", {
       local okLG, errLG = pcall(LetsGo.update, dt)
       if not okLG and not V.letsGoWarned then
         V.letsGoWarned = true
-        mod.log:warn("LET'S GO update failed: %s", tostring(errLG))
+        local msg = ("LET'S GO update failed: %s"):format(tostring(errLG))
+        V.log:error("%s", msg)
+        V.dlog(msg)
       end
     end
     -- The overworld battle rides this hook rather than owning a pipeline of
@@ -305,9 +355,69 @@ mod.content.render_pipelines:register("voxel", {
     -- canvas it was handed, so the sky's dither, the water's march and the
     -- camera itself all come out the same picture at a higher sample rate.
     local rw, rh = AntiAlias.expand(sw, sh)
-    local canvas = VoxelScene.render(ctx.state, rw, rh,
-                                     ctx.vw, ctx.vh, ctx.paletteFor)
-    if not canvas then return nil end   -- fall back to the 2D path
+    local st = ctx.state
+
+    -- gen2-gold-beta meshKick diagnostics: once per session, name the map
+    -- and force a short pump so a stuck empty cache surfaces as a real
+    -- build failure rather than an endless silent 2D fallback.
+    if st and st.map and not V._meshKick then
+      V._meshKick = true
+      local map = st.map
+      local ts = map.tileset
+      local sample = nil
+      pcall(function() sample = map:tileAt(0, 0) end)
+      V.dlog(("meshKick map=%s tileset=%s hasBlocks=%s tileAt00=%s"):format(
+        tostring(map.id),
+        tostring(ts and ts.id),
+        tostring(ts and ts.blocks ~= nil),
+        tostring(sample)))
+      local okB, errB = pcall(function()
+        ChunkMesher.request(map, true, {}, true)
+        ChunkMesher.request(map, false, {}, true)
+        for _ = 1, 30 do
+          ChunkMesher.pump(true)
+          if ChunkMesher.pair(map, true) or ChunkMesher.pair(map, false) then
+            break
+          end
+        end
+      end)
+      if not okB then V.dlog("meshKick error: " .. tostring(errB)) end
+      local body = select(1, ChunkMesher.pair(map, true))
+      local full = select(1, ChunkMesher.pair(map, false))
+      V.dlog(("meshKick after pump pending=%s body=%s full=%s"):format(
+        tostring(ChunkMesher.pending()),
+        tostring(body ~= nil),
+        tostring(full ~= nil)))
+    end
+
+    local okDraw, canvas = pcall(VoxelScene.render, st, rw, rh,
+                                 ctx.vw, ctx.vh, ctx.paletteFor)
+    if not okDraw then
+      if not V.drawWorldWarned then
+        V.drawWorldWarned = true
+        V.dlog(("drawWorld 3D failed: %s"):format(tostring(canvas)))
+      end
+      return nil
+    end
+    if not canvas then
+      if not V._nilDrawLogged then
+        V._nilDrawLogged = true
+        local map = st and st.map
+        local body = map and select(1, ChunkMesher.pair(map, true))
+        local full = map and select(1, ChunkMesher.pair(map, false))
+        V.dlog(("drawWorld nil canvas map=%s pending=%s body=%s full=%s"):format(
+          tostring(map and map.id),
+          tostring(ChunkMesher.pending()),
+          tostring(body ~= nil),
+          tostring(full ~= nil)))
+      end
+      return nil   -- fall back to the 2D path
+    end
+    if not V._drawOkLogged then
+      V._drawOkLogged = true
+      V.dlog(("drawWorld 3D ok map=%s"):format(
+        tostring(st and st.map and st.map.id)))
+    end
     if Voxel3D.beginOverlay() then
       -- the FX closures are ordinary 2D draws sized in DISPLAY pixels, and
       -- they are drawing into the supersampled canvas alongside everything
@@ -660,7 +770,8 @@ local function cycleVoxel(game)
   if Horde.viewLocked() then return false end
   local top = game.stack and game.stack:top()
   if not Pipelines.canToggle("voxel", top, game.overworld) then return false end
-  Pipelines.setLevel("voxel", Voxel.nextHotkeyLevel(Pipelines.level("voxel")))
+  local nextLevel = Voxel.nextHotkeyLevel(Pipelines.level("voxel"))
+  Pipelines.setLevel("voxel", nextLevel)
   Pipelines.syncOptions(game.save.options)
   -- 3 is the key that used to turn TILT on and sits next to the one that
   -- used to turn GBC FX on, and this mod has taken both away. A player who
@@ -672,6 +783,7 @@ local function cycleVoxel(game)
   require("src.render.GBCFX").setLevel(0)
   require("src.render.Tilt").setLevel(game.save.options.tilt or 0)
   game:writeOptions()
+  V.log:event("voxel", "cycle", { level = nextLevel })
   return true
 end
 
@@ -1049,6 +1161,12 @@ mod.events:on("map.reloaded", function(payload)
   -- the atmosphere's layout stands on the same carved stamps the meshes
   -- do, so it goes stale on exactly the same event
   if mapId then ForestAtmos.invalidate(mapId) end
+  if V.log then
+    V.log:event("map", "reloaded", {
+      map = mapId or "unknown",
+      reason = payload and payload.reason or "unknown",
+    })
+  end
 end)
 
 -- ------- rows come and go, so the menu has to notice
@@ -1248,8 +1366,16 @@ mod.events:on("save.created", function() ShinyBattle.markParty() end)
 -- per-cell consequence still runs through the engine's own machinery
 -- (onStepComplete, checkEdgeExit, checkLedgeHop, checkBoulderPush). The
 -- file argues the whole arrangement.
-FirstPerson.install()
-FreeMove.install()
+do
+  local ok, err = pcall(FirstPerson.install)
+  if ok then V.log:event("input", "FirstPerson.install", { ok = "true" })
+  else V.log:error("FirstPerson.install failed: %s", tostring(err)) end
+end
+do
+  local ok, err = pcall(FreeMove.install)
+  if ok then V.log:event("input", "FreeMove.install", { ok = "true" })
+  else V.log:error("FreeMove.install failed: %s", tostring(err)) end
+end
 
 -- ------- the zooms, and the battle camera the player can steer
 --
@@ -1260,7 +1386,11 @@ FreeMove.install()
 -- wrap installed later is the OUTER one, so a fight gets first refusal on
 -- the mouse and the fingers, which is right, because while one is staged
 -- the free-roam look is not driving.
-CamControl.install()
+do
+  local ok, err = pcall(CamControl.install)
+  if ok then V.log:event("input", "CamControl.install", { ok = "true" })
+  else V.log:error("CamControl.install failed: %s", tostring(err)) end
+end
 
 -- ------- SELECT walks the angle ladder
 --
@@ -1346,6 +1476,10 @@ end
 -- shown.
 mod.events:on("battle.started", function(payload)
   OverworldBattle.ensure(payload and payload.battle)
+  local b = payload and payload.battle
+  V.log:event("battle", "started", {
+    kind = b and b.kind or "unknown",
+  })
 end)
 
 -- Both mons face the camera, so the player's side wants its FRONT pic where
@@ -1372,6 +1506,7 @@ end)
 -- so this is where the map's cast comes back.
 mod.events:on("battle.ended", function()
   OverworldBattle.finish()
+  V.log:event("battle", "ended", {})
 end)
 
 -- ------- and the way back out
@@ -1414,17 +1549,25 @@ mod.events:on("save.writing", function()
 end)
 
 mod.events:on("save.loaded", function()
+  local okG, Game = pcall(require, "src.core.Game")
+  if okG and Game then ModStorage.setGame(Game) end
   DayNight.restore()
   -- a save written before this mod was installed can carry TILT or GBC FX
   -- switched on, and their rows are not there to switch them back off (see
   -- pinEngineFx). Answered here rather than only when the menu opens, so a
   -- player who never opens it is not left playing under one.
   pinEngineFx()
+  V.log:event("save", "loaded", {})
+  pcall(function() V.log:flush() end)
 end)
 
 mod.events:on("save.created", function()
+  local okG, Game = pcall(require, "src.core.Game")
+  if okG and Game then ModStorage.setGame(Game) end
   DayNight.restore()
   pinEngineFx()
+  V.log:event("save", "created", {})
+  pcall(function() V.log:flush() end)
 end)
 
 -- The engine's own time-of-day seam. OverworldState:timeOfDay() is an
@@ -1442,3 +1585,21 @@ mod.exports.version = "1.5.5"
 -- exposed so a companion mod can pin its own tiles' shapes or read the
 -- camera without reaching into this mod's file layout
 mod.exports.lib = V
+-- Diagnostic ring buffer (also under mod.storage key diagnostics/log).
+mod.exports.diagnosticLog = function()
+  return V.log and V.log:contents() or ""
+end
+mod.exports.flushDiagnostics = function()
+  return V.log and V.log:flush()
+end
+
+-- Options row: SAVE DIAGNOSTIC SNAPSHOT (forces a flush to mod.storage).
+mod.hooks:wrap("ui.options.rows", function(next, game, rows)
+  local out = next(game, rows)
+  if type(out) ~= "table" then return out end
+  if game then ModStorage.setGame(game) end
+  out[#out + 1] = ModLogExport.row()
+  return out
+end)
+
+V.log:info("main.lua load complete")


### PR DESCRIPTION
Replace scattered print/mod.log diagnostics with a single sandbox-safe
logger persisted under mod.storage (diagnostics/log).

- Add ModStorage / ModLog / ModLogExport; export diagnosticLog and a
  SAVE DIAGNOSTIC SNAPSHOT options row.
- Port gen2-gold-beta V.dlog call sites (load, first update tick,
  meshKick, drawWorld nil/ok/fail) via a V.dlog bridge into ModLog.
- Route ForestAtmos, VR, OverworldBattle, HordeSfx, Sky, Water,
  StadiumInstall, StadiumScreen, Perf, and ChunkMesher messages through
  V.log / V.dlog instead of bare print or V.mod.log.
