### PR TITLE
fix: trigger release workflow on dev instead of master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [dev]
     paths-ignore:
       - '.github/**'
       - '**.md'


### PR DESCRIPTION
The release workflow was configured to run on pushes to `master`, but this repository uses `dev` as the default branch and has no `master` branch.

This change updates the trigger so the automated release runs on `dev`.

Also keeps the existing `workflow_dispatch` so releases can still be triggered manually.
