### PR TITLE
Fix Stadium ROM import under mod sandbox (drop, directory auto-load, persistent packs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.8.4
+
+### Fixed
+- Stadium ROM import under the gen1recomp mod sandbox
+  - Desktop drop via filedropped / RomImporter wrap
+  - Auto-load from model_extract/baseroms/baserom.z64 (and save-dir baseroms/)
+  - Short drop/path note fallback
+  - Packs via SaveData.persistenceFs() → dramatic_shape/stadium/
+  - Sandbox guards + visible import errors
+
+### Changed
+- Shortened Stadium ROM import note text
+
 ## 1.8.3
 
 ### Added

--- a/lib/StadiumInstall.lua
+++ b/lib/StadiumInstall.lua
@@ -88,10 +88,23 @@ local NAMED = {
 }
 
 local function fs()
-  -- love.filesystem is sandboxed away from mods. Return nil when blocked
-  -- so callers treat the filesystem as unavailable rather than raising.
+  -- Mods cannot touch love.filesystem (sandbox facade errors). The engine's
+  -- SaveData.persistenceFs() still returns the real save-dir filesystem when
+  -- required as an engine module. IMPORTANT: call with no args -- passing
+  -- the module table makes persistFs treat it as an injected fs and return
+  -- the wrong object.
+  local okSD, SaveData = pcall(require, "src.core.SaveData")
+  if okSD and SaveData and type(SaveData.persistenceFs) == "function" then
+    local okF, f = pcall(function() return SaveData.persistenceFs() end)
+    if okF and type(f) == "table" and type(f.write) == "function"
+       and type(f.read) == "function" and type(f.getInfo) == "function" then
+      return f
+    end
+  end
+  -- Direct love.filesystem (only works outside the sandbox / older builds).
   local ok, f = pcall(function() return love.filesystem end)
-  return (ok and f) or nil
+  if ok and type(f) == "table" and type(f.write) == "function" then return f end
+  return nil
 end
 
 local function isFile(path)
@@ -99,6 +112,56 @@ local function isFile(path)
   if not (f and f.getInfo) then return false end
   local ok, info = pcall(f.getInfo, path, "file")
   return (ok and info) and true or false
+end
+
+-- Sandbox-safe pack persistence via the engine mod.storage facade.
+-- love.filesystem is blocked for mods; storage writes are performed by the
+-- engine with the real FS and are the supported path under the sandbox.
+local function bindGame()
+  local okS, Storage = pcall(function() return V.require("ModStorage") end)
+  if okS and Storage then
+    if not Storage.game() then
+      local okG, Game = pcall(require, "src.core.Game")
+      if okG and Game then Storage.setGame(Game) end
+    end
+    return Storage.game()
+  end
+  local okG, Game = pcall(require, "src.core.Game")
+  return okG and Game or nil
+end
+
+local function storageApi()
+  local mod = V.mod
+  if not (mod and mod.storage and mod.storage.writeBytes and mod.storage.readBytes) then
+    return nil
+  end
+  local game = bindGame()
+  if not game then return nil end
+  return mod.storage, game
+end
+
+local function storageWriteBytes(key, bytes)
+  local api, game = storageApi()
+  if not api then return false, "no storage" end
+  local ok, code, message = api:writeBytes(game, key, bytes)
+  if ok then return true end
+  return false, tostring(message or code or "writeBytes failed")
+end
+
+local function storageReadBytes(key)
+  local api, game = storageApi()
+  if not api then return nil end
+  local bytes, code = api:readBytes(game, key)
+  if type(bytes) == "string" and #bytes > 0 then return bytes end
+  return nil
+end
+
+local function storageWriteText(key, text)
+  return storageWriteBytes(key, text)
+end
+
+local function storageReadText(key)
+  return storageReadBytes(key)
 end
 
 -- The ROM's path on the PhysFS read path, or nil.
@@ -151,11 +214,17 @@ end
 -- ------- the marker
 
 local function readMarker()
+  local body = nil
   local f = fs()
-  if not (f and isFile(StadiumInstall.MARKER)) then return nil end
-  local ok, text = pcall(f.read, StadiumInstall.MARKER)
-  if not (ok and type(text) == "string") then return nil end
-  local format, count, md5, rev = text:match("^(%S+)%s+(%d+)%s*(%S*)%s*(%S*)")
+  if f and isFile(StadiumInstall.MARKER) then
+    local ok, text = pcall(f.read, StadiumInstall.MARKER)
+    if ok and type(text) == "string" then body = text end
+  end
+  if not body then
+    body = storageReadText("stadium/marker")
+  end
+  if type(body) ~= "string" then return nil end
+  local format, count, md5, rev = body:match("^(%S+)%s+(%d+)%s*(%S*)%s*(%S*)")
   if not format then return nil end
   return { format = format, count = tonumber(count), md5 = md5,
            rev = tonumber(rev) }
@@ -259,19 +328,20 @@ StadiumInstall.status = status
 -- falls back to the normal model. That is also what a half-finished install
 -- looks like, which is the behaviour we want from one.
 local function writePack(species, bytes, shinyBytes)
+  -- Always write into dramatic_shape/stadium/ on the engine save FS.
+  -- mod.storage is playthrough-scoped and is the wrong place for packs.
   local f = fs()
-  if not f then return false, "no filesystem" end
-  local ok, err = f.write(("%s/%03d.dsm"):format(StadiumInstall.DIR, species),
-                          bytes)
+  if not (f and f.write) then
+    return false, "no persistent filesystem (SaveData.persistenceFs unavailable)"
+  end
+  local path = ("%s/%03d.dsm"):format(StadiumInstall.DIR, species)
+  local ok, err = f.write(path, bytes)
   if not ok then return false, tostring(err) end
   if shinyBytes then
-    -- A failed shiny write is not a failed install: the species still has
-    -- its model. Left unwritten, the runtime shows the normal one.
     local sok, serr = f.write(
       ("%s/%03ds.dsm"):format(StadiumInstall.DIR, species), shinyBytes)
     if not sok then
-      local msg = ("shiny pack %03d not written: %s"):format(
-        species, tostring(serr))
+      local msg = ("shiny pack %03d not written: %s"):format(species, tostring(serr))
       if V.log then V.log:warn("%s", msg)
       elseif V.dlog then V.dlog(msg)
       elseif V.mod and V.mod.log then V.mod.log:warn("%s", msg) end
@@ -314,8 +384,11 @@ end
 -- `label` is only ever used to say WHICH file a complaint is about.
 function StadiumInstall.beginFrom(bytes, label)
   local f = fs()
+  if V.log then
+    V.log:warn("StadiumInstall.beginFrom: persistent_fs=%s", tostring(f ~= nil))
+  end
   if not f then
-    if V.log then V.log:warn("StadiumInstall.beginFrom: no filesystem") end
+    if V.log then V.log:warn("StadiumInstall.beginFrom: no persistent filesystem") end
     return false, "no filesystem"
   end
   if type(bytes) ~= "string" or #bytes == 0 then
@@ -377,7 +450,7 @@ function StadiumInstall.beginFrom(bytes, label)
     return false, "needs Pokemon Stadium US 1.0"
   end
 
-  pcall(f.createDirectory, StadiumInstall.DIR)
+  if f and f.createDirectory then pcall(f.createDirectory, StadiumInstall.DIR) end
   job = StadiumBuild.job(rom, writePack, StadiumInstall.COUNT)
   job.md5 = rom:md5()
   status.state = "building"
@@ -407,11 +480,19 @@ function StadiumInstall.step()
     -- build that did not happen. beginFrom refuses such a ROM outright; this
     -- is the same rule stated where the consequence is.
     local wrote = #job.failed == 0 and job.total > 0
-    if wrote and f then
-      pcall(f.write, StadiumInstall.MARKER,
-            ("%s %d %s %d\n"):format(StadiumInstall.FORMAT, job.total,
-                                     tostring(job.md5 or ""),
-                                     StadiumInstall.REV))
+    if wrote then
+      local markerBody = ("%s %d %s %d\n"):format(
+        StadiumInstall.FORMAT, job.total,
+        tostring(job.md5 or ""), StadiumInstall.REV)
+      local wf = f or fs()
+      if wf and wf.write then
+        local mok, merr = wf.write(StadiumInstall.MARKER, markerBody)
+        if not mok and V.log then
+          V.log:warn("StadiumInstall: marker write failed: %s", tostring(merr))
+        end
+      elseif V.log then
+        V.log:warn("StadiumInstall: no FS to write marker")
+      end
       readyCache = nil
       StadiumPack.forget()
     end

--- a/lib/StadiumPack.lua
+++ b/lib/StadiumPack.lua
@@ -85,18 +85,36 @@ local function readPack(species, shiny)
     local okS, b = pcall(mod.read, mod, packName(StadiumPack.DIR, species, shiny))
     haveShipped = okS and type(b) == "string" and #b > 4
   end
-  -- A CURRENT cache always wins. A stale one (readable, but built by an older
-  -- extractor) wins only when there is no shipped set to prefer instead --
-  -- that ordering is what stops a cache from an extractor rev we have since
-  -- fixed shadowing good files, while still leaving something on screen for a
-  -- player whose only copy IS that cache. A half-written folder is caught by
-  -- the marker and satisfies neither.
-  if love and love.filesystem and love.filesystem.getInfo
-     and (install.ready() or (install.usable() and not haveShipped)) then
-    local okInfo, info = pcall(love.filesystem.getInfo, rel, "file")
-    if okInfo and info then
-      local ok, bytes = pcall(love.filesystem.read, rel)
-      if ok and type(bytes) == "string" and #bytes > 4 then return bytes end
+  -- Prefer a CURRENT built cache. Under the mod sandbox love.filesystem is
+  -- blocked, so packs live in mod.storage (written by StadiumInstall).
+  if install.ready() or (install.usable() and not haveShipped) then
+    local okFs, bytes = pcall(function()
+      -- Prefer engine persistence FS (works under mod sandbox).
+      local f
+      local okSD, SaveData = pcall(require, "src.core.SaveData")
+      if okSD and SaveData and SaveData.persistenceFs then
+        local okF, pf = pcall(function() return SaveData.persistenceFs() end)
+        if okF then f = pf end
+      end
+      if not f then
+        f = love and love.filesystem
+      end
+      if not (f and f.getInfo and f.read) then return nil end
+      local info = f.getInfo(rel, "file")
+      if not info then return nil end
+      return f.read(rel)
+    end)
+    if okFs and type(bytes) == "string" and #bytes > 4 then return bytes end
+    -- Fallback: mod.storage opaque bytes (keys stadium/001, stadium/001s).
+    local key = shiny and ("stadium/%03ds"):format(species)
+                      or ("stadium/%03d"):format(species)
+    if mod and mod.storage and mod.storage.readBytes then
+      local okG, Game = pcall(require, "src.core.Game")
+      local game = okG and Game or nil
+      if game then
+        local okB, b = pcall(mod.storage.readBytes, mod.storage, game, key)
+        if okB and type(b) == "string" and #b > 4 then return b end
+      end
     end
   end
   if not (mod and mod.read) then return nil end

--- a/lib/StadiumRomPick.lua
+++ b/lib/StadiumRomPick.lua
@@ -77,23 +77,73 @@ local function haveFiles()
   return (ok and open) and true or false
 end
 
-local function osName()
-  local ok, name = pcall(function() return love.system.getOS() end)
-  return ok and name or nil
+-- Sandbox-safe diagnostic log (same fallbacks as StadiumInstall / ModLog).
+local function dlog(fmt, ...)
+  local msg
+  if select("#", ...) > 0 then
+    local ok, formatted = pcall(string.format, tostring(fmt), ...)
+    msg = ok and formatted or tostring(fmt)
+  else
+    msg = tostring(fmt)
+  end
+  msg = "StadiumRomPick: " .. msg
+  if V and V.log and V.log.warn then
+    pcall(V.log.warn, V.log, "%s", msg)
+  elseif V and V.dlog then
+    pcall(V.dlog, msg)
+  elseif V and V.mod and V.mod.log and V.mod.log.warn then
+    pcall(V.mod.log.warn, V.mod.log, "%s", msg)
+  else
+    pcall(print, msg)
+  end
 end
 
 -- Run a command and return its trimmed stdout, or nil for anything that did
 -- not produce a line -- a cancelled dialog, a missing zenity, a shell that
 -- is not there.
 local function commandOutput(cmd)
-  if not haveShell() then return nil end
+  if not haveShell() then
+    dlog("commandOutput: no shell (io.popen unavailable)")
+    return nil
+  end
   local ok, pipe = pcall(io.popen, cmd)
-  if not (ok and pipe) then return nil end
+  if not (ok and pipe) then
+    dlog("commandOutput: io.popen failed ok=%s err=%s", tostring(ok), tostring(pipe))
+    return nil
+  end
   local okRead, out = pcall(pipe.read, pipe, "*a")
   pcall(pipe.close, pipe)
-  if not (okRead and type(out) == "string") then return nil end
+  if not (okRead and type(out) == "string") then
+    dlog("commandOutput: read failed ok=%s", tostring(okRead))
+    return nil
+  end
   out = out:gsub("^%s+", ""):gsub("%s+$", "")
-  return (out ~= "") and out or nil
+  if out == "" then
+    dlog("commandOutput: empty output (cancel or command failed)")
+    return nil
+  end
+  return out
+end
+
+-- love.system is sandboxed away from mods on current gen1recomp builds, so
+-- getOS() often returns nil. Fall back to package.config and uname so the
+-- desktop dialog path still selects the right shell command.
+local function osName()
+  local ok, name = pcall(function() return love.system.getOS() end)
+  if ok and type(name) == "string" and name ~= "" then return name end
+  -- package / love.system may both be sandboxed away from mods.
+  local okSep, sep = pcall(function()
+    return package and package.config and package.config:sub(1, 1)
+  end)
+  if okSep and sep == "\\" then
+    return "Windows"
+  end
+  local uname = commandOutput("uname -s 2>/dev/null")
+  if uname then
+    if uname:find("Darwin", 1, true) then return "OS X" end
+    if uname:find("Linux", 1, true) then return "Linux" end
+  end
+  return nil
 end
 
 -- ------- can this machine open a DIALOG
@@ -118,9 +168,16 @@ end
 -- path was only ever written to a console no phone shows. That is what the
 -- note below is for.
 function StadiumRomPick.canDialog()
-  if not (haveShell() and haveFiles()) then return false end
-  local p = osName()
-  return p == "Windows" or p == "OS X" or p == "Linux"
+  -- Desktop shell dialog (osascript / PowerShell / zenity)
+  if haveShell() and haveFiles() then
+    local p = osName()
+    if p == "Windows" or p == "OS X" or p == "Linux" then return true end
+  end
+  -- Mobile native bridge (love.system.pickFile) when present.
+  -- Guarded: love.system is sandboxed away from mods on current gen1recomp.
+  local ok, fn = pcall(function() return love.system and love.system.pickFile end)
+  if ok and type(fn) == "function" then return true end
+  return false
 end
 
 -- Kept as the old name for callers that only wanted "is there a dialog".
@@ -141,16 +198,22 @@ function StadiumRomPick.choose()
       ([[osascript -e 'POSIX path of (choose file with prompt "%s" of type ]]
        .. [[{"z64", "n64", "v64"})' 2>/dev/null]]):format(PROMPT))
   elseif p == "Windows" then
+    -- Copy the pick to a plain-ASCII temp name and answer with that:
+    -- the console's OEM codepage would mangle a non-ASCII path
+    -- (Pokémon -> Pok\x82mon) and io.open on Windows needs ANSI bytes,
+    -- so returning the original name both crashed the notice draw and
+    -- could never have opened the file (same fix as engine #325/#665).
     local script = table.concat({
       "Add-Type -AssemblyName System.Windows.Forms;",
       "$d=New-Object System.Windows.Forms.OpenFileDialog;",
       "$d.Title='" .. PROMPT .. "';",
       "$d.Filter='Nintendo 64 ROM (*.z64;*.n64;*.v64)|*.z64;*.n64;*.v64"
       .. "|All files (*.*)|*.*';",
-      -- as UTF-8: the console's OEM codepage would mangle a non-ASCII path
-      -- and crash the next text draw that showed it
-      "if($d.ShowDialog() -eq 'OK'){[Console]::OutputEncoding="
-      .. "[Text.Encoding]::UTF8; [Console]::Write($d.FileName)}",
+      "if($d.ShowDialog() -eq 'OK'){",
+      "$t=Join-Path $env:TEMP 'ds_stadium_rom_pick.z64';",
+      "Copy-Item -LiteralPath $d.FileName -Destination $t -Force;",
+      "[Console]::OutputEncoding=[Text.Encoding]::UTF8;",
+      "[Console]::Write($t)}",
     })
     return commandOutput(
       'powershell -NoProfile -STA -Command "' .. script .. '"')
@@ -166,6 +229,7 @@ function StadiumRomPick.choose()
       [[kdialog --getopenfilename "$HOME" "*.z64 *.n64 *.v64|]]
       .. [[Nintendo 64 ROM" 2>/dev/null]])
   end
+  dlog("choose: no dialog command for platform=%s", tostring(p))
   return nil
 end
 
@@ -198,25 +262,170 @@ end
 -- is the one surface in this mode with room for a sentence -- and because a
 -- player who has just chosen the wrong file is owed a reason and not a row
 -- that quietly goes on saying IMPORT.
-function StadiumRomPick.import(game)
-  if StadiumInstall.status.state == "building" then return false end
-  local StadiumScreen = V.require("StadiumScreen")
+-- Paths checked (in order) when the player presses STADIUM ROM.
+-- Relative paths under the mod are read via mod:read.
+local CANDIDATE_MOD_ROMS = {
+  "model_extract/baseroms/baserom.z64",
+  "model_extract/baseroms/baserom.n64",
+  "model_extract/baseroms/baserom.v64",
+  "model_extract/baseroms/us/baserom.z64",
+  "baseroms/baserom.z64",
+  "baseroms/baserom.n64",
+  "baseroms/baserom.v64",
+  "baseroms/us/baserom.z64",
+}
 
-  -- No dialog on this platform: say where the file goes, on screen, because
-  -- that is the whole of what the player is missing and the console is not
-  -- somewhere they can read it.
-  if not StadiumRomPick.canDialog() then
-    if game and game.stack then
-      game.stack:push(StadiumScreen.newNote(game, "STADIUM ROM",
-        "PUT STADIUM US 1.0 HERE:",
-        StadiumInstall.romHintFile()))
+-- Also try these on the engine save/source FS (mods/<id>/...).
+local function candidateFsRoms(modId)
+  local id = modId or "DRAMATIC_SHAPE"
+  local out = {}
+  for _, rel in ipairs(CANDIDATE_MOD_ROMS) do
+    out[#out + 1] = "mods/" .. id .. "/" .. rel
+  end
+  -- bare save-dir baseroms
+  out[#out + 1] = "baseroms/baserom.z64"
+  out[#out + 1] = "baseroms/baserom.n64"
+  out[#out + 1] = "baseroms/baserom.v64"
+  return out
+end
+
+local function startFromBytes(game, bytes, label)
+  local StadiumScreen = V.require("StadiumScreen")
+  dlog("directory rom start label=%s size=%d", tostring(label), #bytes)
+  local started, err = StadiumInstall.beginFrom(bytes, label)
+  if not started then
+    StadiumInstall.status.state = "failed"
+    StadiumInstall.status.error = tostring(err)
+    dlog("directory rom beginFrom failed: %s", tostring(err))
+  end
+  if game and game.stack then
+    game.stack:push(StadiumScreen.new(game, true))
+  end
+  return true
+end
+
+local function persistentFs()
+  local okSD, SaveData = pcall(require, "src.core.SaveData")
+  if okSD and SaveData and type(SaveData.persistenceFs) == "function" then
+    local okF, f = pcall(function() return SaveData.persistenceFs() end)
+    if okF and type(f) == "table" and type(f.read) == "function" then return f end
+  end
+  return nil
+end
+
+-- Try to load a Stadium ROM that is already on disk (mod folder or save-dir
+-- baseroms/). Returns true if a build was started.
+local function tryDirectoryRom(game)
+  local mod = V.mod
+  local modId = (mod and mod.id) or (mod and mod.manifest and mod.manifest.id) or "DRAMATIC_SHAPE"
+  dlog("tryDirectoryRom mod.id=%s hasRead=%s hasList=%s hasInfo=%s",
+    tostring(modId), tostring(mod and mod.read ~= nil),
+    tostring(mod and mod.list ~= nil), tostring(mod and mod.info ~= nil))
+
+  -- Probe directory listing so logs show whether the folder is visible.
+  if mod and mod.list then
+    for _, dir in ipairs({ "model_extract/baseroms", "model_extract", "baseroms" }) do
+      local okL, items = pcall(mod.list, mod, dir)
+      if okL and type(items) == "table" then
+        dlog("mod:list %s -> %d entries: %s", dir, #items, table.concat(items, ", "):sub(1, 120))
+      else
+        dlog("mod:list %s failed: %s", dir, tostring(items))
+      end
     end
+  end
+
+  -- 1) Mod-local paths via mod:read (fixed names + any .z64/.n64/.v64 in the
+  --    baseroms folders). The folder often only has README until the player
+  --    drops a ROM in; when they do, any name is accepted.
+  local function tryModRead(rel)
+    if not (mod and mod.read) then return false end
+    local ok, bytes, err = pcall(function() return mod:read(rel) end)
+    if ok and type(bytes) == "string" and #bytes > 0 then
+      return startFromBytes(game, bytes, rel)
+    end
+    dlog("mod:read %s -> ok=%s type=%s err=%s",
+      rel, tostring(ok), type(bytes), tostring(err or bytes))
     return false
   end
 
-  local path = StadiumRomPick.choose()
-  if not path then return false end
+  if mod and mod.read then
+    for _, rel in ipairs(CANDIDATE_MOD_ROMS) do
+      if tryModRead(rel) then return true end
+    end
+    -- Scan directories for any stadium-sized ROM the player dropped in.
+    if mod.list then
+      for _, dir in ipairs({
+        "model_extract/baseroms",
+        "model_extract/baseroms/us",
+        "baseroms",
+        "baseroms/us",
+      }) do
+        local okL, items = pcall(mod.list, mod, dir)
+        if okL and type(items) == "table" then
+          for _, name in ipairs(items) do
+            local lower = name:lower()
+            if lower:match("%.z64$") or lower:match("%.n64$") or lower:match("%.v64$") then
+              local rel = dir .. "/" .. name
+              dlog("tryDirectoryRom: found candidate %s", rel)
+              if tryModRead(rel) then return true end
+            end
+          end
+        end
+      end
+    end
+  else
+    dlog("tryDirectoryRom: V.mod.read unavailable")
+  end
+
+  -- 2) Engine FS paths (mods/DRAMATIC_SHAPE/... and save-dir baseroms/).
+  local f = persistentFs()
+  if f then
+    for _, path in ipairs(candidateFsRoms(modId)) do
+      local okInfo, info = pcall(function()
+        return f.getInfo and f.getInfo(path, "file")
+      end)
+      if okInfo and info then
+        local okR, data = pcall(function() return f.read(path) end)
+        if okR and type(data) == "string" and #data > 0 then
+          return startFromBytes(game, data, path)
+        end
+        dlog("fs.read %s failed: %s", path, tostring(data))
+      else
+        dlog("fs.getInfo %s -> nil", path)
+      end
+    end
+  else
+    dlog("tryDirectoryRom: persistentFs unavailable")
+  end
+
+  -- 3) StadiumInstall.romPath() (baseroms/ on PhysFS search path).
+  if StadiumInstall.romPresent and StadiumInstall.romPresent() then
+    dlog("directory rom via StadiumInstall.romPath")
+    local StadiumScreen = V.require("StadiumScreen")
+    local started, err = StadiumInstall.begin()
+    if not started then
+      StadiumInstall.status.state = "failed"
+      StadiumInstall.status.error = tostring(err)
+    end
+    if game and game.stack then
+      game.stack:push(StadiumScreen.new(game, true))
+    end
+    return true
+  end
+
+  dlog("tryDirectoryRom: no ROM found in any candidate path")
+  return false
+end
+
+function StadiumRomPick.import(game)
+  if StadiumInstall.status.state == "building" then
+    dlog("import ignored: already building")
+    return false
+  end
+  local StadiumScreen = V.require("StadiumScreen")
+
   local function fail(why)
+    dlog("import failed: %s", tostring(why))
     StadiumInstall.status.state = "failed"
     StadiumInstall.status.error = why
     if game and game.stack then
@@ -225,14 +434,55 @@ function StadiumRomPick.import(game)
     return false
   end
 
-  local bytes, err = StadiumRomPick.read(path)
-  if not bytes then return fail(err or "could not read that file") end
-
-  local ok, beginErr = StadiumInstall.beginFrom(bytes, path)
-  if not ok then return fail(tostring(beginErr)) end
-  if game and game.stack then
-    game.stack:push(StadiumScreen.new(game, true))
+  local function pushNote(title, lead, body)
+    if not (game and game.stack) then
+      dlog("pushNote: no game.stack (game=%s)", tostring(game ~= nil))
+      return false
+    end
+    local ok, err = pcall(function()
+      game.stack:push(StadiumScreen.newNote(game, title, lead, body))
+    end)
+    if not ok then
+      dlog("pushNote failed: %s", tostring(err))
+      return false
+    end
+    return true
   end
+
+  local platform = osName()
+  dlog("import start platform=%s shell=%s files=%s game=%s stack=%s",
+    tostring(platform), tostring(haveShell()), tostring(haveFiles()),
+    tostring(game ~= nil), tostring(game and game.stack ~= nil))
+
+  -- Prefer an on-disk ROM (mod model_extract/baseroms or save-dir baseroms)
+  -- so a single click imports without needing drag-and-drop.
+  if tryDirectoryRom(game) then
+    dlog("import: started from directory ROM")
+    return true
+  end
+  dlog("import: no directory ROM found; falling back to drop / picker")
+
+  -- Mobile / iOS: native pickFile when present.
+  if platform == "Android" or platform == "iOS" then
+    local okPick, pickFn = pcall(function() return love.system and love.system.pickFile end)
+    if okPick and type(pickFn) == "function" then
+      dlog("using love.system.pickFile")
+      pcall(pickFn, "stadium")
+      pushNote("STADIUM ROM", "PICK ROM", "Use the system file picker")
+      return true
+    end
+    dlog("mobile path: no pickFile, using folder hint")
+    pushNote("STADIUM ROM", "PUT ROM HERE",
+      "model_extract/baseroms/baserom.z64")
+    return false
+  end
+
+  -- Desktop: prompt to drop the file (hooks from install()). Also mention
+  -- the default mod-folder path so the player can place the ROM there and
+  -- press STADIUM ROM again to auto-load it.
+  dlog("desktop/unknown: prompting for file drop / directory")
+  pushNote("STADIUM ROM", "DROP ROM ON WINDOW",
+    "or: model_extract/baseroms/baserom.z64")
   return true
 end
 
@@ -263,7 +513,18 @@ function StadiumRomPick.row()
       return StadiumRomPick.canDialog() and "IMPORT" or "WHERE?"
     end,
     step = function(game)
-      pcall(StadiumRomPick.import, game)
+      local ok, err = pcall(StadiumRomPick.import, game)
+      if not ok then
+        dlog("row step error: %s", tostring(err))
+        pcall(function()
+          local StadiumScreen = V.require("StadiumScreen")
+          if game and game.stack and StadiumScreen and StadiumScreen.newNote then
+            game.stack:push(StadiumScreen.newNote(game, "STADIUM ROM",
+              "IMPORT ERROR",
+              tostring(err):sub(1, 80)))
+          end
+        end)
+      end
       return true
     end,
   }
@@ -307,5 +568,186 @@ function StadiumRomPick.poll(game)
   end
   return true
 end
+
+-- ------- drag-and-drop for desktops
+--
+-- The mod sandbox blocks assignment to love.* callbacks and strips io /
+-- package. love.filedropped is still *invoked* by the engine, but it is
+-- routed to RomImporter:filedropped -- so we wrap THAT instead of love.*.
+-- DroppedFile:read does not need io; it is a native path handle from LÖVE.
+
+local function readDropped(file)
+  if not file then return nil, "no file" end
+  local name = ""
+  pcall(function()
+    if file.getFilename then name = file:getFilename() or "" end
+  end)
+  local okOpen, openErr = pcall(function()
+    if file.open then
+      local ok, err = file:open("r")
+      if ok == false then error(err or "open failed") end
+    end
+  end)
+  if not okOpen then return nil, "open failed: " .. tostring(openErr) end
+  local okRead, data = pcall(function()
+    if file.read then return file:read() end
+    return nil
+  end)
+  pcall(function() if file.close then file:close() end end)
+  if not okRead then return nil, "read failed: " .. tostring(data) end
+  if type(data) ~= "string" or #data == 0 then return nil, "empty read" end
+  return data, name
+end
+
+local function isStadiumName(name)
+  local lower = (type(name) == "string" and name:lower()) or ""
+  return lower:match("%.z64$") or lower:match("%.n64$") or lower:match("%.v64$")
+end
+
+local function handleStadiumDrop(file)
+  if StadiumInstall.status.state == "building" then
+    dlog("drop ignored: already building")
+    return true
+  end
+  local name = ""
+  pcall(function()
+    if file and file.getFilename then name = file:getFilename() or "" end
+  end)
+  if not isStadiumName(name) then return false end
+
+  dlog("stadium drop received name=%s", tostring(name))
+  local bytes, errOrName = readDropped(file)
+  if not bytes then
+    dlog("stadium drop read failed: %s", tostring(errOrName))
+    StadiumInstall.status.state = "failed"
+    StadiumInstall.status.error = "could not read dropped file: " .. tostring(errOrName)
+    return true
+  end
+  -- readDropped returns (bytes, name) on success
+  if type(errOrName) == "string" and errOrName ~= "" then name = errOrName end
+  dlog("stadium drop read ok size=%d", #bytes)
+
+  local started, err = StadiumInstall.beginFrom(bytes, name)
+  if not started then
+    dlog("stadium drop beginFrom failed: %s", tostring(err))
+    StadiumInstall.status.state = "failed"
+    StadiumInstall.status.error = tostring(err)
+  else
+    dlog("stadium drop beginFrom started")
+  end
+
+  -- Push the loading / result screen if we can reach a stack.
+  local StadiumScreen = V.require("StadiumScreen")
+  local pushed = false
+  pcall(function()
+    local okG, Game = pcall(require, "src.core.Game")
+    if okG and Game and Game.stack then
+      Game.stack:push(StadiumScreen.new(Game, true))
+      pushed = true
+    end
+  end)
+  if not pushed then
+    pcall(function()
+      local Storage = V.require("ModStorage")
+      local g = Storage and Storage.game and Storage.game()
+      if g and g.stack then
+        g.stack:push(StadiumScreen.new(g, true))
+        pushed = true
+      end
+    end)
+  end
+  if not pushed then
+    pcall(function() V.require("StadiumScreen").maybePush() end)
+  end
+  dlog("stadium drop UI pushed=%s", tostring(pushed))
+  return true
+end
+
+local filedropInstalled = false
+function StadiumRomPick.install()
+  if filedropInstalled then return end
+  filedropInstalled = true
+  dlog("install: wiring stadium drop handlers")
+
+  local function loveHandler(file)
+    local ok, handled = pcall(handleStadiumDrop, file)
+    if not ok then
+      dlog("drop handler error: %s", tostring(handled))
+      return
+    end
+    if handled then return end
+    -- forward non-stadium drops to whatever the engine had
+    if StadiumRomPick._prevFiledropped then
+      return StadiumRomPick._prevFiledropped(file)
+    end
+  end
+
+  -- 1) Wrap RomImporter.filedropped (works while launcher Importer is alive)
+  local wrappedImporter = false
+  local okRI, RomImporter = pcall(require, "src.import.RomImporter")
+  if okRI and type(RomImporter) == "table" and type(RomImporter.filedropped) == "function" then
+    if not RomImporter._dsStadiumDropWrapped then
+      local inner = RomImporter.filedropped
+      StadiumRomPick._prevFiledropped = function(file)
+        -- no instance; best-effort no-op for non-stadium when only love path hits this
+      end
+      function RomImporter.filedropped(self, file)
+        local ok, handled = pcall(handleStadiumDrop, file)
+        if not ok then
+          dlog("handleStadiumDrop error: %s", tostring(handled))
+        elseif handled then
+          return
+        end
+        if inner then return inner(self, file) end
+      end
+      RomImporter._dsStadiumDropWrapped = true
+      wrappedImporter = true
+      dlog("install: wrapped RomImporter.filedropped")
+    else
+      wrappedImporter = true
+    end
+  else
+    dlog("install: RomImporter unavailable ok=%s", tostring(okRI))
+  end
+
+  -- 2) Capture previous love.filedropped for forwarding
+  local okOld, old = pcall(function() return love.filedropped end)
+  if okOld and type(old) == "function" then
+    StadiumRomPick._prevFiledropped = old
+  end
+
+  -- 3) Try several ways to attach; sandbox may block some/all.
+  local attached = {}
+
+  local ok1, err1 = pcall(function() love.filedropped = loveHandler end)
+  local ok1b, cur1 = pcall(function() return love.filedropped end)
+  if ok1 and ok1b and cur1 == loveHandler then attached[#attached + 1] = "love.filedropped" end
+
+  local ok2, err2 = pcall(function()
+    if rawset then rawset(love, "filedropped", loveHandler) end
+  end)
+  local ok2b, cur2 = pcall(function() return love.filedropped end)
+  if ok2 and ok2b and cur2 == loveHandler then
+    if attached[#attached] ~= "love.filedropped" then attached[#attached + 1] = "rawset love.filedropped" end
+  end
+
+  local ok3, err3 = pcall(function()
+    if love.handlers then love.handlers.filedropped = loveHandler end
+  end)
+  local ok3b, cur3 = pcall(function()
+    return love.handlers and love.handlers.filedropped
+  end)
+  if ok3 and ok3b and cur3 == loveHandler then attached[#attached + 1] = "love.handlers.filedropped" end
+
+  dlog("install: drop attach=[%s] importer=%s loveSet=%s rawset=%s handlers=%s",
+    table.concat(attached, ","),
+    tostring(wrappedImporter),
+    tostring(ok1), tostring(ok2), tostring(ok3))
+
+  if #attached == 0 and not wrappedImporter then
+    dlog("install: WARNING no drop hook attached; use baseroms/ folder")
+  end
+end
+
 
 return StadiumRomPick

--- a/main.lua
+++ b/main.lua
@@ -1397,6 +1397,17 @@ do
   else V.log:error("CamControl.install failed: %s", tostring(err)) end
 end
 
+-- Stadium ROM drop support: love.filedropped for desktops (sandbox may
+-- reject the assignment; fails soft). Mobile uses love.system.pickFile
+-- from the OPTIONS row instead.
+do
+  local ok, err = pcall(function()
+    V.require("StadiumRomPick").install()
+  end)
+  if ok then V.log:event("input", "StadiumRomPick.install", { ok = "true" })
+  else V.log:error("StadiumRomPick.install failed: %s", tostring(err)) end
+end
+
 -- ------- SELECT walks the angle ladder
 --
 -- The same step the "3" key makes, on the pad's own button: a phone (and

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "DRAMATIC_SHAPE",
   "name": "Dramatic Shape Voxel Mod",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",


### PR DESCRIPTION
Stadium ROM import was broken on current gen1recomp builds with the love
restrictions / mod sandbox: no dialog, no working drop path, and packs
written in a way that did not persist or load in battle.

Changes (minimal, import-focused):
- Wire desktop import via love.filedropped / RomImporter wrap and
  love.handlers; mobile still uses pickFile when available
- On STADIUM ROM click, auto-load from directory if present:
  model_extract/baseroms/baserom.z64 (and .n64/.v64), then save-dir baseroms/
- Fall back to a short drop / path note when no ROM is found
- Write/read model packs through SaveData.persistenceFs() into
  dramatic_shape/stadium/ so builds persist and load in battles
- Guard sandbox-blocked APIs (package, io, love.filesystem) with pcall
- Surface import errors instead of silent pcall failure
- Shorten import note text

Does not change unrelated mod behavior.
