### PR TITLE
perf(android): persist voxel meshes between sessions

### DIFF
--- a/lib/ChunkMesher.lua
+++ b/lib/ChunkMesher.lua
@@ -56,11 +56,21 @@ local Buildings = V.require("Buildings")
 local TileShape = V.require("TileShape")
 local Voxel3D = V.require("Voxel3D")
 local Budget = V.require("BuildBudget")
+local MeshCache = V.require("VoxelMeshCache")
 
 local ffi = nil
 do
   local ok, mod = pcall(require, "ffi")
   if ok then ffi = mod end
+end
+
+-- love.system itself is sandboxed; current Gen1Recomp's compatibility facade
+-- answers getOS while older sandboxes raise. Fail closed on those older builds
+-- rather than changing desktop scheduling.
+local IS_ANDROID = false
+do
+  local ok, osName = pcall(function() return love.system.getOS() end)
+  IS_ANDROID = ok and osName == "Android"
 end
 
 local ChunkMesher = {}
@@ -203,7 +213,7 @@ local function newFfiSink()
       local ok, mesh = pcall(function()
         local m = love.graphics.newMesh(Voxel3D.FORMAT, n,
                                         "triangles", "static")
-        local CHUNK = 65536              -- vertices per slice (~1.5MB)
+        local CHUNK = IS_ANDROID and MeshCache.CHUNK_VERTICES or 65536
         local i = 0
         while i < n do
           local count = math.min(CHUNK, n - i)
@@ -229,6 +239,32 @@ local function newSink()
     return newFfiSink()
   end
   return newTableSink()
+end
+
+local function persistentCapable()
+  return MeshCache.available() and love and love.data
+         and love.data.newByteData and love.graphics
+         and love.graphics.newMesh
+end
+
+-- MeshCache hands back the exact interleaved six-float bytes expected by
+-- Voxel3D.FORMAT. ByteData can be uploaded directly: no FFI pointer or copy is
+-- needed, which is what keeps this path valid in the current mod sandbox.
+local function cachedMeshReceiver(_, count)
+  local mesh = love.graphics.newMesh(Voxel3D.FORMAT, count,
+                                     "triangles", "static")
+  return {
+    write = function(self, raw, first)
+      local data = love.data.newByteData(raw)
+      mesh:setVertices(data, first + 1)
+      if data.release then data:release() end
+    end,
+    finish = function() return mesh end,
+    abort = function()
+      if mesh and mesh.release then pcall(mesh.release, mesh) end
+      mesh = nil
+    end,
+  }
 end
 
 -- -------------------------------------------------------------- geometry
@@ -914,6 +950,42 @@ function ChunkMesher.build(map, bodyOnly, masks, split)
   return sink.finish(), waterSink and waterSink.finish() or nil
 end
 
+function ChunkMesher.persistentCacheAvailable()
+  return persistentCapable() and true or false
+end
+
+function ChunkMesher.bodyCachedOnDisk(map)
+  if not persistentCapable() then return false end
+  local hit = MeshCache.status(map)
+  return hit and true or false
+end
+
+-- Generate BODY directly into bounded persistent chunks. Unlike V19's raw
+-- sink, this does not retain the whole map in an FFI buffer: each terrain or
+-- water chunk is packed, optionally LZ4-compressed and committed independently.
+function ChunkMesher.precompileBody(map)
+  if not (persistentCapable() and map) then return false, "unsupported" end
+  if ChunkMesher.bodyCachedOnDisk(map) then return true, "cached" end
+  local store, reason = MeshCache.beginStore(map)
+  if not store then return false, reason end
+  local ok, err = pcall(runGeometry, map, true, nil,
+                        store:sink("body"), store:sink("water"))
+  if not ok then
+    store:abort()
+    return false, tostring(err)
+  end
+  local stored, storeReason = store:commit()
+  return stored, stored and "built" or storeReason
+end
+
+function ChunkMesher.persistentCacheVersion()
+  return MeshCache.SCHEMA_VERSION, MeshCache.GEOMETRY_VERSION
+end
+
+function ChunkMesher.persistentCacheDirectory()
+  return MeshCache.DIRECTORY
+end
+
 local function quadsMesh(quads, grass)
   if #quads == 0 then return nil end
   local verts, indices, n = {}, {}, 0
@@ -1072,6 +1144,63 @@ end
 local function runJob(job)
   local map = job.map
   local c = entry(job.id)
+
+  -- BODY jobs prefer the persistent stream. A corrupt/truncated entry is
+  -- rejected by MeshCache, its ready marker is removed, and this job becomes
+  -- ordinary cold work before it can continue.
+  local mesh, water = nil, nil
+  local loaded = false
+  local attemptedPersistent = job.slot == "body"
+      and job.allowPersistent ~= false and job.persistent
+  if attemptedPersistent then
+    loaded, mesh, water = MeshCache.load(map, cachedMeshReceiver)
+    if not loaded then job.persistent = false end
+  end
+  -- Do not turn a cached-neighbour upload that proved corrupt into a large
+  -- live generation in the same walking frame.
+  if not loaded and attemptedPersistent and job.moving and not job.urgent then
+    coroutine.yield("cache-miss")
+  end
+
+  -- A cache miss on Android also generates through the bounded persistent
+  -- sinks. This replaces V19's FFI staging buffer (FFI is no longer exposed
+  -- to content mods): geometry is written in 4K-vertex chunks, then streamed
+  -- into the GPU by the same checked load path. Stale runtime edits never take
+  -- this route, because persisting a Cut/door state globally would be wrong.
+  if not loaded and job.slot == "body" and job.allowPersistent ~= false
+     and persistentCapable() then
+    local stored = ChunkMesher.precompileBody(map)
+    if stored then
+      loaded, mesh, water = MeshCache.load(map, cachedMeshReceiver)
+    end
+  end
+
+  if not loaded then
+    local sink, waterSink = newSink(), newSink()
+    runGeometry(map, job.slot == "body", job.masks, sink, waterSink)
+    mesh, water = sink.finish(), waterSink.finish()
+  end
+
+  if (gen[job.id] or 0) ~= job.gen then
+    if mesh and mesh.release then pcall(mesh.release, mesh) end
+    if water and water.release then pcall(water.release, water) end
+    return
+  end
+  swapSlot(c, job.slot, mesh or false)
+  swapSlot(c, waterSlot(job.slot), water or false)
+  if c.stale then c.stale[job.slot] = nil end
+
+  -- Terrain becomes drawable before optional grass/flower/figure work. Keep
+  -- the existing v1.8.4 auxiliary behavior, but resume it only in idle or
+  -- covered time so a cheap persistent BODY cannot drag a Structures build
+  -- into the same walking frame.
+  if not job.covered then
+    job.terrainReady = true
+    job.urgent = false
+    job.warm = 0
+    coroutine.yield("terrain-ready")
+  end
+
   if c.grass == nil or c.flowers == nil or c.figures == nil
      or (c.stale and c.stale.aux) then
     local okG, grass = pcall(buildGrassMesh, map)
@@ -1091,23 +1220,8 @@ local function runJob(job)
     c.figures = (okX and figures) or false
     if c.stale then c.stale.aux = nil end
   end
-  local sink = newSink()
-  local waterSink = newSink()
-  runGeometry(map, job.slot == "body", job.masks, sink, waterSink)
-  local mesh = sink.finish()
-  local water = waterSink.finish()
-  if (gen[job.id] or 0) ~= job.gen then
-    if mesh and mesh.release then pcall(mesh.release, mesh) end
-    if water and water.release then pcall(water.release, water) end
-    return
-  end
-  swapSlot(c, job.slot, mesh or false)
-  swapSlot(c, waterSlot(job.slot), water or false)
-  if c.stale then
-    c.stale[job.slot] = nil
-    if not (c.stale.full or c.stale.body or c.stale.aux) then
-      c.stale = nil
-    end
+  if c.stale and not (c.stale.full or c.stale.body or c.stale.aux) then
+    c.stale = nil
   end
 end
 
@@ -1118,20 +1232,31 @@ end
 -- stale queues its rebuild AND keeps handing back the old mesh, so a
 -- one-block edit never drops the scene to the flat 2D path while the
 -- replacement cooks.
-function ChunkMesher.request(map, bodyOnly, masks, urgent)
+function ChunkMesher.request(map, bodyOnly, masks, urgent, warm)
   local slot = bodyOnly and "body" or "full"
   local c = cache[map.id]
   local stale = c and c.stale and (c.stale[slot] or c.stale.aux)
   if c and c[slot] ~= nil and not stale then return c[slot] or nil end
+
+  local persistent = bodyOnly and not stale and ChunkMesher.bodyCachedOnDisk(map)
+                     or false
   local key = jobKey(map.id, slot)
   local job = jobIndex[key]
   if not job then
     job = { id = map.id, map = map, slot = slot, masks = masks,
-            urgent = urgent or false, gen = gen[map.id] or 0 }
+            urgent = urgent or false, warm = warm or 0,
+            persistent = persistent,
+            allowPersistent = bodyOnly and not stale,
+            gen = gen[map.id] or 0 }
     jobIndex[key] = job
     jobs[#jobs + 1] = job
-  elseif urgent then
-    job.urgent = true
+  else
+    job.persistent = persistent
+    if stale then job.allowPersistent = false end
+    -- Priorities are live: turning away from a connection or making BODY
+    -- drawable must demote an already queued job.
+    if urgent ~= nil then job.urgent = urgent and true or false end
+    if warm ~= nil then job.warm = warm or 0 end
   end
   return (c and c[slot]) or nil
 end
@@ -1140,33 +1265,79 @@ function ChunkMesher.pending()
   return #jobs
 end
 
+function ChunkMesher.failed(map, bodyOnly)
+  local c = map and cache[map.id] or nil
+  return c and c[bodyOnly and "body" or "full"] == false or false
+end
+
 -- Advance queued builds inside a per-frame time budget. Urgent jobs (the
 -- current map) come first and get the larger slice -- the first voxel
 -- frame after a toggle is worth more milliseconds than a neighbour
 -- popping in one frame later. `covered` says the world pass is hidden
 -- this frame (a warp's fade, a menu): nothing visible can hitch, so the
 -- slice opens up and a door fade swallows most of a destination build.
-local URGENT_SLICE = 0.012
-local IDLE_SLICE = 0.005
-local COVERED_SLICE = 0.030
+local URGENT_SLICE = IS_ANDROID and 0.0020 or 0.012
+local IDLE_SLICE = IS_ANDROID and 0.0008 or 0.005
+local MOVING_URGENT_SLICE = IS_ANDROID and 0.0009 or URGENT_SLICE
+local MOVING_CACHE_SLICE = IS_ANDROID and 0.0006 or IDLE_SLICE
+local IDLE_CACHE_SLICE = IS_ANDROID and 0.0030 or IDLE_SLICE
+local COVERED_CACHE_SLICE = 0.030
+local COVERED_HEAVY_SLICE = IS_ANDROID and 0.0080 or 0.030
 
-function ChunkMesher.pump(covered)
-  if #jobs == 0 then return end
-  local pick = jobs[1]
-  for _, j in ipairs(jobs) do
-    if j.urgent then
-      pick = j
-      break
+local function chooseJob(moving)
+  if #jobs == 0 then return nil, false, false end
+  local warmPick, warmValue = nil, -math.huge
+  for _, job in ipairs(jobs) do
+    if job.urgent and not job.terrainReady then return job, true, false end
+    -- During Android movement a cold warm job cannot run. Do not let it hide
+    -- a lower-priority persistent neighbour that can make cheap progress.
+    if not (IS_ANDROID and moving) or job.persistent then
+      local value = job.warm or 0
+      if not job.terrainReady and value > warmValue then
+        warmPick, warmValue = job, value
+      end
     end
   end
-  local slice = covered and COVERED_SLICE
-                or (pick.urgent and URGENT_SLICE or IDLE_SLICE)
+  if warmPick and warmValue > 0 then return warmPick, false, true end
+  return jobs[1], false, false
+end
+
+local function walkingAllows(job, urgentPick, warmPick, android)
+  if not android then return true end
+  if job.terrainReady then return false end
+  return urgentPick or (warmPick and job.persistent) or false
+end
+
+function ChunkMesher.pump(covered, moving)
+  if #jobs == 0 then return end
+  local pick, urgentPick, warmPick = chooseJob(moving)
+  if not pick then return end
+  if moving and not covered
+     and not walkingAllows(pick, urgentPick, warmPick, IS_ANDROID) then
+    return
+  end
+
+  local slice
+  if covered then
+    slice = pick.persistent and COVERED_CACHE_SLICE or COVERED_HEAVY_SLICE
+  elseif moving then
+    slice = pick.persistent and MOVING_CACHE_SLICE
+            or (urgentPick and MOVING_URGENT_SLICE or 0)
+  elseif pick.persistent then
+    slice = IDLE_CACHE_SLICE
+  else
+    slice = urgentPick and URGENT_SLICE or IDLE_SLICE
+  end
+  if slice <= 0 then return end
+
   local deadline = clock() + slice
   while pick do
     if not pick.co then
       pick.co = coroutine.create(runJob)
     end
-    Budget.begin(pick.co, deadline - clock())
+    pick.covered = covered and true or false
+    pick.moving = moving and not covered
+    Budget.begin(pick.co, math.max(0, deadline - clock()))
     local ok, err = coroutine.resume(pick.co, pick)
     Budget.finish()
     if not ok then
@@ -1177,15 +1348,20 @@ function ChunkMesher.pump(covered)
       return   -- slice spent mid-build; resume next frame
     end
     if clock() >= deadline or #jobs == 0 then return end
-    pick = jobs[1]
-    for _, j in ipairs(jobs) do
-      if j.urgent then
-        pick = j
-        break
-      end
+    pick, urgentPick, warmPick = chooseJob(moving)
+    if not pick then return end
+    if moving and not covered
+       and not walkingAllows(pick, urgentPick, warmPick, IS_ANDROID) then
+      return
     end
   end
 end
+
+ChunkMesher._test = {
+  walkingAllows = function(job, urgentPick, warmPick)
+    return walkingAllows(job, urgentPick, warmPick, true)
+  end,
+}
 
 -- Meshes for `map`, built SYNCHRONOUSLY on first use -- the historical
 -- contract, kept for probes and any direct caller. `false` is cached for
@@ -1284,6 +1460,11 @@ function ChunkMesher.refresh(mapId)
     return ChunkMesher.invalidate(mapId)
   end
   Structures.invalidate(mapId)
+  -- Runtime block edits also invalidate the memoized persistent fingerprint.
+  -- The on-disk entry itself is retained: status() will reject it if the
+  -- rebuilt map/layout fingerprint differs, and can reuse it if an edit was
+  -- subsequently reverted before the next load.
+  MeshCache.forget(mapId)
   gen[mapId] = (gen[mapId] or 0) + 1
   for i = #jobs, 1, -1 do
     local job = jobs[i]
@@ -1319,6 +1500,7 @@ function ChunkMesher.setLive(live)
       cache[id] = nil
       gen[id] = (gen[id] or 0) + 1
       Structures.invalidate(id)
+      MeshCache.forget(id)
     end
   end
   for i = #jobs, 1, -1 do
@@ -1337,6 +1519,7 @@ end
 -- the generation counter.
 function ChunkMesher.invalidate(mapId)
   Structures.invalidate(mapId)
+  MeshCache.forget(mapId)
   if mapId then
     local c = cache[mapId]
     if c then releaseEntry(c) end

--- a/lib/VoxelCacheScreen.lua
+++ b/lib/VoxelCacheScreen.lua
@@ -1,0 +1,286 @@
+-- One-time Android preparation for persistent voxel BODY geometry.
+--
+-- Large map generation is moved off the traversal path. Every map commits
+-- independently, so closing or skipping this opaque screen keeps completed
+-- work and the next run resumes at the first missing fingerprint.
+
+local V = ...
+
+local Budget = V.require("BuildBudget")
+local ChunkMesher = V.require("ChunkMesher")
+local MeshCache = V.require("VoxelMeshCache")
+local Structures = V.require("Structures")
+
+local Screen = {}
+Screen.__index = Screen
+Screen.isOpaque = true
+
+local W, H = 160, 144
+local MIN_AREA = 24 -- blocks: routes/towns/forest, not tiny interiors
+local SLICE = 0.018
+local HOLD = 0.65
+
+local asked = false
+local active = false
+local Font = nil
+
+local function font()
+  if Font then return Font end
+  local ok, value = pcall(require, "src.render.Font")
+  if ok then Font = value end
+  return Font
+end
+
+local function text(value, x, y)
+  local f = font()
+  if not f then return end
+  love.graphics.setColor(0, 0, 0, 1)
+  f.draw(tostring(value), math.floor(x), math.floor(y))
+end
+
+local function centred(value, y)
+  local f = font()
+  if not f then return end
+  value = tostring(value)
+  text(value, (W - f.width(value)) / 2, y)
+end
+
+local function candidates(game)
+  local ids, signatureParts = {}, {}
+  local maps = game and game.data and game.data.maps or {}
+  for id, def in pairs(maps) do
+    local width = type(def) == "table" and tonumber(def.width) or nil
+    local height = type(def) == "table" and tonumber(def.height) or nil
+    -- Some engine revisions leave dimensions to MapLoader. Keep those ids and
+    -- decide after load rather than silently missing an outdoor map.
+    if not (width and height) or width * height >= MIN_AREA then
+      ids[#ids + 1] = id
+    end
+  end
+  table.sort(ids, function(a, b) return tostring(a) < tostring(b) end)
+  for _, id in ipairs(ids) do
+    local def = maps[id]
+    signatureParts[#signatureParts + 1] = table.concat({
+      tostring(id),
+      tostring(type(def) == "table" and def.width or "?"),
+      tostring(type(def) == "table" and def.height or "?"),
+      tostring(type(def) == "table" and def.tileset or "?"),
+    }, ":")
+  end
+  return ids, MeshCache.warmupSignature(signatureParts)
+end
+
+local function trimLoadedMaps(game, MapLoader)
+  if not (MapLoader and MapLoader.trim) then return end
+  local protected = {}
+  local ow = game and game.overworld
+  if ow and ow.map and ow.map.id then protected[ow.map.id] = true end
+  for _, nb in ipairs((ow and ow.neighbors) or {}) do
+    if nb.map and nb.map.id then protected[nb.map.id] = true end
+  end
+  pcall(MapLoader.trim, protected)
+end
+
+function Screen.new(game, ids, signature)
+  if not ids then ids, signature = candidates(game) end
+  return setmetatable({
+    game = game,
+    ids = ids,
+    signature = signature,
+    index = 1,
+    done = 0,
+    built = 0,
+    skipped = 0,
+    failed = 0,
+    current = nil,
+    currentName = "",
+    co = nil,
+    hold = 0,
+    finished = false,
+  }, Screen)
+end
+
+function Screen:enter()
+  active = true
+end
+
+function Screen:exit()
+  active = false
+end
+
+local function pop(self)
+  active = false
+  if self.game and self.game.stack and self.game.stack:top() == self then
+    self.game.stack:pop()
+  end
+end
+
+local function nextMap(self)
+  local MapLoader = require("src.world.MapLoader")
+  while self.index <= #self.ids do
+    local id = self.ids[self.index]
+    self.index = self.index + 1
+    local ok, map = pcall(MapLoader.load, self.game.data, id)
+    if ok and map and map.def then
+      local area = (tonumber(map.def.width) or 0)
+                   * (tonumber(map.def.height) or 0)
+      if area >= MIN_AREA then
+        self.current = map
+        self.currentName = tostring(map.id or id)
+        if ChunkMesher.bodyCachedOnDisk(map) then
+          self.done = self.done + 1
+          self.skipped = self.skipped + 1
+          Structures.invalidate(map.id)
+          MeshCache.forget(map.id)
+          self.current = nil
+          trimLoadedMaps(self.game, MapLoader)
+        else
+          self.co = coroutine.create(function()
+            return ChunkMesher.precompileBody(map)
+          end)
+          return true
+        end
+      else
+        self.done = self.done + 1
+      end
+    else
+      self.done = self.done + 1
+      self.failed = self.failed + 1
+    end
+  end
+  return false
+end
+
+function Screen:update()
+  if self.finished then
+    self.hold = self.hold + 1 / 60
+    if self.hold >= HOLD then pop(self) end
+    return
+  end
+
+  local input = self.game and self.game.input
+  if input and input.wasPressed and input:wasPressed("b") then
+    pop(self)
+    return
+  end
+
+  if not self.co then
+    if not nextMap(self) then
+      if self.failed == 0 then MeshCache.markWarmupComplete(self.signature) end
+      self.finished = true
+      self.hold = 0
+      return
+    end
+    if not self.co then return end
+  end
+
+  Budget.begin(self.co, SLICE)
+  local ok, result = coroutine.resume(self.co)
+  Budget.finish()
+  if not ok then
+    self.failed = self.failed + 1
+    pcall(function()
+      V.log:warn("voxel cache: %s failed: %s",
+                 tostring(self.currentName), tostring(result))
+    end)
+  end
+
+  if not ok or coroutine.status(self.co) == "dead" then
+    if ok and result then
+      self.built = self.built + 1
+    elseif ok then
+      self.failed = self.failed + 1
+    end
+    self.done = self.done + 1
+    if self.current and self.current.id then
+      Structures.invalidate(self.current.id)
+      MeshCache.forget(self.current.id)
+    end
+    local okLoader, MapLoader = pcall(require, "src.world.MapLoader")
+    if okLoader then trimLoadedMaps(self.game, MapLoader) end
+    self.current, self.co = nil, nil
+    collectgarbage("step", 300)
+  end
+end
+
+function Screen:onKeyPressed(key)
+  if key == "escape" or key == "backspace" or key == "x" then
+    pop(self)
+    return true
+  end
+  return false
+end
+
+function Screen:draw()
+  love.graphics.setColor(0.93, 0.94, 0.90, 1)
+  love.graphics.rectangle("fill", 0, 0, W, H)
+  centred("VOXEL CACHE", 18)
+  centred("ONE-TIME SETUP", 32)
+
+  local total = math.max(1, #self.ids)
+  local fraction = math.max(0, math.min(1, self.done / total))
+  if self.finished then fraction = 1 end
+  local x, y, width, height = 20, 66, 120, 9
+  love.graphics.setColor(0.06, 0.05, 0.09, 1)
+  love.graphics.rectangle("fill", x - 1, y - 1, width + 2, height + 2)
+  love.graphics.setColor(0.93, 0.94, 0.90, 1)
+  love.graphics.rectangle("fill", x, y, width, height)
+  love.graphics.setColor(0.06, 0.05, 0.09, 1)
+  love.graphics.rectangle("fill", x, y, math.floor(width * fraction + 0.5), height)
+
+  if self.finished then
+    if self.failed == 0 then
+      centred("READY", 86)
+      centred("3D MAPS CACHED", 100)
+    else
+      centred("CACHE PARTIAL", 86)
+      centred(("%d FAILED"):format(self.failed), 100)
+    end
+  else
+    centred(("%d/%d"):format(self.done, #self.ids), 84)
+    local name = self.currentName ~= "" and self.currentName or "SCANNING MAPS"
+    if #name > 18 then name = name:sub(1, 18) end
+    centred(name, 98)
+    centred("KEEP APP OPEN", 112)
+    centred("B: SKIP FOR NOW", 128)
+  end
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+function Screen.active()
+  return active
+end
+
+function Screen.maybePush()
+  if asked then return false end
+  if not ChunkMesher.persistentCacheAvailable() then
+    asked = true
+    return false
+  end
+  local ok, Game = pcall(require, "src.core.Game")
+  if not (ok and Game and Game.stack and Game.overworld) then return false end
+  if Game.stack:top() ~= Game.overworld then return false end
+  local Voxel = V.require("VoxelState")
+  if not (Voxel.active and Voxel.active()) then return false end
+
+  asked = true
+  local ids, signature = candidates(Game)
+  local complete = MeshCache.warmupComplete(signature)
+  local map = Game.overworld.map
+  local area = map and map.def
+               and (tonumber(map.def.width) or 0) * (tonumber(map.def.height) or 0)
+               or 0
+  if complete and (area < MIN_AREA or ChunkMesher.bodyCachedOnDisk(map)) then
+    return false
+  end
+  Game.stack:push(Screen.new(Game, ids, signature))
+  return true
+end
+
+function Screen._reset()
+  asked, active = false, false
+end
+
+Screen._test = { candidates = candidates, minArea = MIN_AREA }
+
+return Screen

--- a/lib/VoxelMeshCache.lua
+++ b/lib/VoxelMeshCache.lua
@@ -1,0 +1,695 @@
+-- Persistent BODY geometry for the voxel world.
+--
+-- ChunkMesher remains the sole owner of geometry generation, invalidation and
+-- GPU objects. This module fingerprints BODY inputs and stores the resulting
+-- unindexed six-float vertex stream in independent, checksummed chunks.
+--
+-- Current Gen1Recomp sandboxes love.filesystem and FFI. Persistence therefore
+-- goes through SaveData.persistenceFs() (already used by this mod's Stadium
+-- cache under its engine_internals permission), with the official opaque-byte
+-- mod.storage API as a fallback on runtimes that expose it. love.data remains
+-- available to content mods and supplies float packing plus optional LZ4.
+
+local V = ...
+
+local Budget = V.require("BuildBudget")
+
+local Cache = {}
+
+-- Container schema and geometry meaning are deliberately separate. Bump the
+-- schema when records change; bump GEOMETRY_VERSION when BODY generation or a
+-- geometry-affecting data table changes while the record layout stays valid.
+Cache.SCHEMA_VERSION = 2
+Cache.GEOMETRY_VERSION = "v184-body-1"
+Cache.VERSION = Cache.SCHEMA_VERSION
+Cache.CHUNK_VERTICES = 4096
+Cache.VERTEX_FLOATS = 6
+Cache.VERTEX_BYTES = Cache.VERTEX_FLOATS * 4
+Cache.DIRECTORY = "dramatic_shape/voxel_mesh_cache_v"
+                  .. Cache.SCHEMA_VERSION
+
+local MAX_VERTICES = 4000000
+local MAX_CHUNKS = math.ceil(MAX_VERTICES / Cache.CHUNK_VERTICES)
+local UINT32 = 4294967296
+local TRI_ORDER = { 1, 2, 3, 1, 3, 4 }
+
+local testBackend = nil
+local runtimeBackend = nil
+local memo = {}
+local sourceDigest = nil
+local atlasDigests = {}
+local Assets = nil
+
+local function dataApi()
+  return (testBackend and testBackend.data) or (love and love.data)
+end
+
+local function isAndroid()
+  if testBackend and testBackend.android ~= nil then
+    return testBackend.android and true or false
+  end
+  local ok, osName = pcall(function() return love.system.getOS() end)
+  return ok and osName == "Android"
+end
+
+local function ensureParent(fs, path)
+  local dir = path:match("^(.*)/[^/]+$")
+  if dir and fs.createDirectory then
+    local ok, made = pcall(fs.createDirectory, dir)
+    return ok and made ~= false
+  end
+  return true
+end
+
+local function persistenceBackend()
+  local okSave, SaveData = pcall(require, "src.core.SaveData")
+  if not (okSave and SaveData and SaveData.persistenceFs) then return nil end
+  local okFs, fs = pcall(SaveData.persistenceFs)
+  if not (okFs and fs and fs.read and fs.write and fs.getInfo) then return nil end
+
+  local function pathFor(key)
+    return Cache.DIRECTORY .. "/" .. key .. ".dsvc"
+  end
+  return {
+    name = "persistence-fs",
+    read = function(key)
+      local path = pathFor(key)
+      local okInfo, info = pcall(fs.getInfo, path, "file")
+      if not (okInfo and info) then return nil end
+      local ok, bytes = pcall(fs.read, path)
+      return (ok and type(bytes) == "string") and bytes or nil
+    end,
+    write = function(key, bytes)
+      local path = pathFor(key)
+      if not ensureParent(fs, path) then return false, "create directory" end
+      local ok, wrote, err = pcall(fs.write, path, bytes)
+      if not ok then return false, tostring(wrote) end
+      if wrote == false or wrote == nil then return false, tostring(err or "write") end
+      return true
+    end,
+    delete = function(key)
+      if not fs.remove then return false end
+      local ok = pcall(fs.remove, pathFor(key))
+      return ok
+    end,
+  }
+end
+
+local function storageBackend()
+  local storage = V.mod and V.mod.storage
+  if not (storage and storage.readBytes and storage.writeBytes
+          and storage.delete) then
+    return nil
+  end
+  local okGame, game = pcall(function() return V.mod.game end)
+  if not (okGame and game) then return nil end
+  return {
+    name = "mod-storage-bytes",
+    read = function(key)
+      local ok, bytes = pcall(storage.readBytes, storage, game, key)
+      return (ok and type(bytes) == "string") and bytes or nil
+    end,
+    write = function(key, bytes)
+      local ok, wrote, code, message = pcall(
+          storage.writeBytes, storage, game, key, bytes)
+      if not ok then return false, tostring(wrote) end
+      if not wrote then return false, tostring(message or code or "write") end
+      return true
+    end,
+    delete = function(key)
+      local ok = pcall(storage.delete, storage, game, key)
+      return ok
+    end,
+  }
+end
+
+local function backend()
+  if testBackend then return testBackend end
+  if runtimeBackend then return runtimeBackend end
+  -- Preserve V19's one-cache-for-all-saves semantics when the maintained
+  -- runtime's persistence router is reachable. Opaque mod.storage is the
+  -- supported fallback for a future runtime that closes the internal route.
+  runtimeBackend = persistenceBackend() or storageBackend()
+  return runtimeBackend
+end
+
+function Cache.available()
+  local data = dataApi()
+  return isAndroid() and backend() ~= nil and data ~= nil
+         and type(data.pack) == "function"
+         and type(data.newByteData) == "function"
+end
+
+local function safeId(id)
+  return tostring(id):gsub("[^%w_%-]", "_")
+end
+
+local function hashBytes(value)
+  local h = 5381
+  value = tostring(value or "")
+  for i = 1, #value do
+    h = (h * 65599 + value:byte(i) + 257) % UINT32
+  end
+  return string.format("%08x", h)
+end
+
+-- Cache compatibility follows the code and authored profile that actually
+-- determine BODY vertices, not just a manually maintained version string.
+-- This also makes developer hot reloads safe when the manifest version has
+-- not changed. mod:read is the supported sandbox route for bundled sources.
+local SOURCE_FILES = {
+  "lib/ChunkMesher.lua",
+  "lib/Structures.lua",
+  "lib/Buildings.lua",
+  "lib/TileShape.lua",
+  "data/voxel_heights.lua",
+}
+
+local function sourceFingerprint()
+  if sourceDigest then return sourceDigest end
+  local parts = {}
+  for _, path in ipairs(SOURCE_FILES) do
+    local ok, value = pcall(function() return V.mod:read(path) end)
+    value = ok and type(value) == "string" and value or "<missing>"
+    parts[#parts + 1] = path
+    parts[#parts + 1] = tostring(#value)
+    parts[#parts + 1] = value
+  end
+  sourceDigest = hashBytes(table.concat(parts, "\0"))
+  return sourceDigest
+end
+
+-- Buildings and several structural classifiers inspect atlas pixels. The
+-- path alone is insufficient when another mod overrides that asset in place,
+-- so hash the resolved ImageData bytes once per tileset. Assets.invalidate
+-- clears this memo below.
+local function atlasFingerprint(tileset)
+  local path = tileset and tileset.image
+  if type(path) ~= "string" then return "none" end
+  local resolved = path
+  if Assets and Assets.resolve then
+    local ok, value = pcall(Assets.resolve, path)
+    if ok and type(value) == "string" then resolved = value end
+  end
+  if atlasDigests[resolved] then return atlasDigests[resolved] end
+  local digest = "unreadable"
+  if Assets and Assets.imageData then
+    local okData, imageData = pcall(Assets.imageData, resolved)
+    if okData and imageData and imageData.getString then
+      local okRaw, raw = pcall(imageData.getString, imageData)
+      if okRaw and type(raw) == "string" then digest = hashBytes(raw) end
+    end
+    if imageData and imageData.release then pcall(imageData.release, imageData) end
+  end
+  digest = resolved .. "@" .. digest
+  atlasDigests[resolved] = digest
+  return digest
+end
+
+local function mapKey(map)
+  local id = tostring(map and map.id or "unknown")
+  return "maps/" .. safeId(id) .. "-" .. hashBytes(id)
+end
+
+local function readyKey(map)
+  return mapKey(map) .. "/ready"
+end
+
+local function chunkKey(map, kind, index)
+  return ("%s/%s-%06d"):format(mapKey(map), kind, index)
+end
+
+local COMPLETE_KEY = "complete"
+
+local function newHash()
+  local h = 5381
+  local function addNumber(value)
+    h = (h * 65599 + (tonumber(value) or 0) + 257) % UINT32
+  end
+  local function addString(value)
+    local text = tostring(value or "")
+    addNumber(#text)
+    for i = 1, #text do addNumber(text:byte(i)) end
+  end
+  return function() return h end, addNumber, addString
+end
+
+local function currentVoidFill(explicit)
+  if explicit ~= nil then return tostring(explicit) end
+  local ok, TileRenderer = pcall(require, "src.render.TileRenderer")
+  if ok and TileRenderer then return tostring(TileRenderer.voidFill or "trees") end
+  return "trees"
+end
+
+local function sortedKeys(values)
+  local keys = {}
+  if type(values) ~= "table" then return keys end
+  for key in pairs(values) do keys[#keys + 1] = key end
+  table.sort(keys, function(a, b)
+    local ta, tb = type(a), type(b)
+    if ta ~= tb then return ta < tb end
+    if ta == "number" then return a < b end
+    return tostring(a) < tostring(b)
+  end)
+  return keys
+end
+
+-- Deterministic hash of the inputs BODY geometry reads. The geometry version
+-- handles code/data changes; this fingerprint handles map and runtime inputs.
+function Cache.fingerprint(map, voidFill)
+  if not (map and map.id and map.def and map.tileAt) then return nil end
+  local width, height = tonumber(map.def.width), tonumber(map.def.height)
+  if not (width and height and width >= 0 and height >= 0) then return nil end
+
+  local tileset = map.tileset or {}
+  local finishHash, addNumber, addString = newHash()
+  addString("schema"); addNumber(Cache.SCHEMA_VERSION)
+  addString("geometry"); addString(Cache.GEOMETRY_VERSION)
+  addString("source"); addString(sourceFingerprint())
+  addString("map"); addString(map.id)
+  addString("dimensions"); addNumber(width); addNumber(height)
+  addString("border"); addString(map.def.borderBlock or "")
+  addString("outdoor")
+  addString(map.def.outdoor == nil and "default" or map.def.outdoor)
+  addString("tileset"); addString(tileset.id or map.def.tileset or "?")
+  for _, field in ipairs({ "image", "tilesPerRow", "imageWidth",
+                           "imageHeight", "grassTile", "flowerTile" }) do
+    addString(field); addString(tileset[field] or "")
+  end
+  addString("atlas-bytes"); addString(atlasFingerprint(tileset))
+  addString("void"); addString(currentVoidFill(voidFill))
+
+  local function addTable(label, values)
+    addString(label)
+    if type(values) ~= "table" then addNumber(-1); return end
+    local keys = sortedKeys(values)
+    addNumber(#keys)
+    for _, key in ipairs(keys) do
+      addString(type(key)); addString(key)
+      local value = values[key]
+      if type(value) == "table" then
+        local nested = sortedKeys(value)
+        addNumber(#nested)
+        for _, nk in ipairs(nested) do
+          addString(type(nk)); addString(nk); addString(value[nk])
+        end
+      else
+        addString(type(value)); addString(value)
+      end
+    end
+  end
+
+  addTable("walkable", map.walkable or tileset.walkable)
+  addTable("doors", map.doorTiles or tileset.doorTiles)
+  addTable("warps", map.warpTiles or tileset.warpTiles)
+  addTable("water", map.waterTiles or tileset.waterTiles)
+  addTable("shore", map.shoreTiles or tileset.shoreTiles)
+
+  -- Standard maps expose compact block layout and blockset tables. Hashing
+  -- those directly covers live setBlock edits without thousands of protected
+  -- tileAt calls during an early neighbour prefetch.
+  if type(map.def.blocks) == "table" and type(tileset.blocks) == "table" then
+    addTable("layout", map.def.blocks)
+    addTable("blockset", tileset.blocks)
+  else
+    addString("expanded-tiles")
+    for y = 0, height * 4 - 1 do
+      for x = 0, width * 4 - 1 do
+        local ok, tile = pcall(map.tileAt, map, x, y)
+        if not ok or tonumber(tile) == nil then return nil end
+        addNumber(tile)
+      end
+    end
+  end
+  addString("end")
+  return string.format("%08x", finishHash())
+end
+
+local function expectedChunks(vertices)
+  return vertices == 0 and 0
+         or math.ceil(vertices / Cache.CHUNK_VERTICES)
+end
+
+local function readyBody(fp, bodyVertices, bodyChunks, waterVertices,
+                         waterChunks, schema, geometry)
+  return ("DSVM|%d|%s|%s|%d|%d|%d|%d|%d|%d\n"):format(
+      schema or Cache.SCHEMA_VERSION,
+      geometry or Cache.GEOMETRY_VERSION,
+      fp, bodyVertices, bodyChunks, waterVertices, waterChunks,
+      Cache.CHUNK_VERTICES, Cache.VERTEX_BYTES)
+end
+
+local function parseReady(value)
+  if type(value) ~= "string" or #value > 256 then return nil end
+  local schema, geometry, fp, bodyVertices, bodyChunks,
+        waterVertices, waterChunks, chunkVertices, vertexBytes = value:match(
+      "^DSVM|(%d+)|([^|]+)|([0-9a-fA-F]+)|(%d+)|(%d+)|(%d+)|(%d+)|(%d+)|(%d+)\n$")
+  schema = tonumber(schema)
+  bodyVertices, bodyChunks = tonumber(bodyVertices), tonumber(bodyChunks)
+  waterVertices, waterChunks = tonumber(waterVertices), tonumber(waterChunks)
+  chunkVertices, vertexBytes = tonumber(chunkVertices), tonumber(vertexBytes)
+  if schema ~= Cache.SCHEMA_VERSION
+     or geometry ~= Cache.GEOMETRY_VERSION
+     or not fp or #fp ~= 8
+     or not bodyVertices or bodyVertices < 0 or bodyVertices > MAX_VERTICES
+     or not waterVertices or waterVertices < 0 or waterVertices > MAX_VERTICES
+     or bodyVertices % 3 ~= 0 or waterVertices % 3 ~= 0
+     or bodyChunks ~= expectedChunks(bodyVertices)
+     or waterChunks ~= expectedChunks(waterVertices)
+     or bodyChunks > MAX_CHUNKS or waterChunks > MAX_CHUNKS
+     or chunkVertices ~= Cache.CHUNK_VERTICES
+     or vertexBytes ~= Cache.VERTEX_BYTES then
+    return nil
+  end
+  return {
+    fingerprint = fp:lower(),
+    bodyVertices = bodyVertices,
+    bodyChunks = bodyChunks,
+    waterVertices = waterVertices,
+    waterChunks = waterChunks,
+  }
+end
+
+local function encodeChunk(kind, fp, index, raw)
+  local mode, payload = "R", raw
+  local data = dataApi()
+  if data and data.compress then
+    local ok, packed = pcall(data.compress, "string", "lz4", raw)
+    if ok and type(packed) == "string" and #packed < #raw then
+      mode, payload = "L", packed
+    end
+  end
+  local header = ("DSVC|%d|%s|%s|%s|%06d|%08x|%08x|%s|%s\n"):format(
+      Cache.SCHEMA_VERSION, Cache.GEOMETRY_VERSION, kind, fp, index,
+      #raw, #payload, hashBytes(raw), mode)
+  return header .. payload
+end
+
+local function decodeChunk(value, kind, fp, expectedIndex, expectedBytes)
+  if type(value) ~= "string" then return nil, "missing chunk" end
+  local newline = value:find("\n", 1, true)
+  if not newline or newline > 256 then return nil, "bad chunk header" end
+  local header, payload = value:sub(1, newline), value:sub(newline + 1)
+  local schema, geometry, gotKind, gotFp, index, rawBytes, storedBytes,
+        checksum, mode = header:match(
+      "^DSVC|(%d+)|([^|]+)|([^|]+)|([0-9a-fA-F]+)|(%d+)|([0-9a-fA-F]+)|([0-9a-fA-F]+)|([0-9a-fA-F]+)|([RL])\n$")
+  schema, index = tonumber(schema), tonumber(index)
+  rawBytes, storedBytes = tonumber(rawBytes, 16), tonumber(storedBytes, 16)
+  if schema ~= Cache.SCHEMA_VERSION
+     or geometry ~= Cache.GEOMETRY_VERSION or gotKind ~= kind
+     or not gotFp or gotFp:lower() ~= fp or index ~= expectedIndex
+     or rawBytes ~= expectedBytes or storedBytes ~= #payload
+     or storedBytes <= 0 or storedBytes > expectedBytes + 65536
+     or not checksum or #checksum ~= 8 then
+    return nil, "incompatible chunk"
+  end
+  local raw = payload
+  if mode == "L" then
+    local data = dataApi()
+    if not (data and data.decompress) then return nil, "lz4 unavailable" end
+    local ok, unpacked = pcall(data.decompress, "string", "lz4", payload)
+    if not ok then return nil, "lz4 decode" end
+    raw = unpacked
+  end
+  if type(raw) ~= "string" or #raw ~= expectedBytes then
+    return nil, "truncated chunk"
+  end
+  if hashBytes(raw) ~= checksum:lower() then return nil, "chunk checksum" end
+  return raw
+end
+
+local function remove(cacheBackend, key)
+  if cacheBackend and cacheBackend.delete then pcall(cacheBackend.delete, key) end
+end
+
+function Cache.status(map)
+  if not (map and map.id) then return false, nil end
+  local cached = memo[map.id]
+  if cached and cached.map == map then
+    return cached.hit, cached.fingerprint, cached.meta
+  end
+  local cacheBackend = backend()
+  if not cacheBackend then return false, nil end
+  local fp = Cache.fingerprint(map)
+  local meta = fp and parseReady(cacheBackend.read(readyKey(map))) or nil
+  local hit = meta ~= nil and meta.fingerprint == fp
+  memo[map.id] = {
+    map = map, fingerprint = fp, hit = hit and true or false,
+    meta = hit and meta or nil,
+  }
+  return hit and true or false, fp, hit and meta or nil
+end
+
+function Cache.forget(mapId)
+  if mapId ~= nil then memo[mapId] = nil else memo = {} end
+end
+
+local function newStoreSink(session, kind)
+  local parts, buffered, vertices, chunks = {}, 0, 0, 0
+  local sink = {}
+
+  local function flush()
+    if buffered == 0 then return end
+    local raw = table.concat(parts)
+    chunks = chunks + 1
+    local key = chunkKey(session.map, kind, chunks)
+    local ok, err = session.backend.write(
+        key, encodeChunk(kind, session.fingerprint, chunks, raw))
+    if not ok then error("voxel cache chunk write failed: " .. tostring(err), 0) end
+    session.written[#session.written + 1] = key
+    parts, buffered = {}, 0
+    Budget.check()
+  end
+
+  sink.push = function(corners, uv, shade)
+    local data = dataApi()
+    local flat = type(shade) ~= "table"
+    for k = 1, 6 do
+      local i = TRI_ORDER[k]
+      local c, t = corners[i], uv[i]
+      parts[#parts + 1] = data.pack(
+          "string", "<ffffff", c[1], c[2], c[3], t[1], t[2],
+          tonumber(flat and shade or shade[i]) or 1)
+      buffered = buffered + 1
+      vertices = vertices + 1
+      if vertices > MAX_VERTICES then error("voxel cache vertex limit", 0) end
+      if buffered >= Cache.CHUNK_VERTICES then flush() end
+    end
+  end
+
+  sink.finish = function()
+    flush()
+    return vertices, chunks
+  end
+  return sink
+end
+
+function Cache.beginStore(map)
+  local cacheBackend = backend()
+  local fp = Cache.fingerprint(map)
+  if not cacheBackend then return nil, "storage unavailable" end
+  if not fp then return nil, "fingerprint unavailable" end
+  local previous = parseReady(cacheBackend.read(readyKey(map)))
+  remove(cacheBackend, readyKey(map))
+  remove(cacheBackend, COMPLETE_KEY)
+  memo[map.id] = nil
+
+  local session = {
+    map = map,
+    backend = cacheBackend,
+    fingerprint = fp,
+    previous = previous,
+    written = {},
+    sinks = {},
+    finished = false,
+  }
+
+  function session:sink(kind)
+    assert(kind == "body" or kind == "water", "unknown cache stream")
+    if not self.sinks[kind] then self.sinks[kind] = newStoreSink(self, kind) end
+    return self.sinks[kind]
+  end
+
+  function session:abort()
+    if self.finished then return end
+    self.finished = true
+    remove(self.backend, readyKey(self.map))
+    for _, key in ipairs(self.written) do remove(self.backend, key) end
+    memo[self.map.id] = nil
+  end
+
+  function session:commit()
+    if self.finished then return false, "store already finished" end
+    local body = self:sink("body")
+    local water = self:sink("water")
+    local bodyVertices, bodyChunks = body.finish()
+    local waterVertices, waterChunks = water.finish()
+    if bodyVertices % 3 ~= 0 or waterVertices % 3 ~= 0 then
+      self:abort()
+      return false, "non-triangle vertex count"
+    end
+    local ok, err = self.backend.write(readyKey(self.map), readyBody(
+        self.fingerprint, bodyVertices, bodyChunks,
+        waterVertices, waterChunks))
+    if not ok then
+      self:abort()
+      return false, err or "ready marker write"
+    end
+    self.finished = true
+
+    -- Remove chunks left by a previous, larger generation after the new ready
+    -- marker is durable. They are never consulted by the new metadata.
+    local previous = self.previous
+    if previous then
+      for i = bodyChunks + 1, previous.bodyChunks do
+        remove(self.backend, chunkKey(self.map, "body", i))
+      end
+      for i = waterChunks + 1, previous.waterChunks do
+        remove(self.backend, chunkKey(self.map, "water", i))
+      end
+    end
+    local meta = {
+      fingerprint = self.fingerprint,
+      bodyVertices = bodyVertices, bodyChunks = bodyChunks,
+      waterVertices = waterVertices, waterChunks = waterChunks,
+    }
+    memo[self.map.id] = {
+      map = self.map, fingerprint = self.fingerprint, hit = true, meta = meta,
+    }
+    return true, self.fingerprint
+  end
+
+  return session
+end
+
+local function abortReceiver(receiver)
+  if receiver and receiver.abort then pcall(receiver.abort, receiver) end
+end
+
+local function loadStream(map, kind, fp, vertices, chunks, receiverFactory,
+                          cacheBackend)
+  if vertices == 0 then return true, nil end
+  local receiver = nil
+  local ok, result = pcall(function()
+    receiver = assert(receiverFactory(kind, vertices))
+    local first = 0
+    for index = 1, chunks do
+      local count = math.min(Cache.CHUNK_VERTICES, vertices - first)
+      local expectedBytes = count * Cache.VERTEX_BYTES
+      local raw, err = decodeChunk(
+          cacheBackend.read(chunkKey(map, kind, index)), kind, fp,
+          index, expectedBytes)
+      assert(raw, err)
+      receiver:write(raw, first, count)
+      first = first + count
+      -- Decompression and the corresponding GPU upload are one bounded unit.
+      -- The scheduler's deadline decides how many units may land this frame.
+      Budget.check()
+    end
+    assert(first == vertices, "cache vertex count")
+    return receiver:finish()
+  end)
+  if not ok then
+    abortReceiver(receiver)
+    return false, nil, tostring(result)
+  end
+  return true, result
+end
+
+local function release(value)
+  if value and value.release then pcall(value.release, value) end
+end
+
+local function markCorrupt(map, cacheBackend)
+  remove(cacheBackend, readyKey(map))
+  remove(cacheBackend, COMPLETE_KEY)
+  memo[map.id] = nil
+end
+
+-- receiverFactory(kind, vertexCount) returns an object with
+-- write(rawBytes, firstVertex, vertexCount), finish(), and optional abort().
+function Cache.load(map, receiverFactory)
+  local hit, fp, meta = Cache.status(map)
+  if not hit then return false, nil, nil, "miss" end
+  local cacheBackend = backend()
+  if not cacheBackend then return false, nil, nil, "storage unavailable" end
+
+  local okBody, body, bodyErr = loadStream(
+      map, "body", fp, meta.bodyVertices, meta.bodyChunks,
+      receiverFactory, cacheBackend)
+  if not okBody then
+    markCorrupt(map, cacheBackend)
+    return false, nil, nil, bodyErr
+  end
+  local okWater, water, waterErr = loadStream(
+      map, "water", fp, meta.waterVertices, meta.waterChunks,
+      receiverFactory, cacheBackend)
+  if not okWater then
+    release(body)
+    markCorrupt(map, cacheBackend)
+    return false, nil, nil, waterErr
+  end
+  return true, body, water
+end
+
+function Cache.warmupSignature(ids, voidFill)
+  local finishHash, _, addString = newHash()
+  addString("warmup")
+  addString(Cache.SCHEMA_VERSION)
+  addString(Cache.GEOMETRY_VERSION)
+  addString(sourceFingerprint())
+  addString(currentVoidFill(voidFill))
+  for _, id in ipairs(ids or {}) do addString(id) end
+  return ("DSVM-WARM|%d|%s|%08x\n"):format(
+      Cache.SCHEMA_VERSION, Cache.GEOMETRY_VERSION, finishHash())
+end
+
+function Cache.warmupComplete(signature)
+  local cacheBackend = backend()
+  return cacheBackend ~= nil and cacheBackend.read(COMPLETE_KEY) == signature
+end
+
+function Cache.markWarmupComplete(signature)
+  local cacheBackend = backend()
+  if not cacheBackend then return false end
+  local ok = cacheBackend.write(COMPLETE_KEY, signature)
+  return ok and true or false
+end
+
+Cache._test = {
+  hashBytes = hashBytes,
+  readyBody = readyBody,
+  parseReady = parseReady,
+  encodeChunk = encodeChunk,
+  decodeChunk = decodeChunk,
+  keys = function(map, kind, index)
+    return readyKey(map), chunkKey(map, kind or "body", index or 1),
+           COMPLETE_KEY
+  end,
+  backendName = function()
+    local value = backend()
+    return value and value.name or nil
+  end,
+  setBackend = function(value)
+    testBackend = value
+    memo = {}
+  end,
+  clearBackend = function()
+    testBackend = nil
+    memo = {}
+  end,
+}
+
+-- The maintained engine's central invalidation is raised for asset overrides
+-- and developer reloads. Clearing both layers forces the next request to
+-- recompute source/atlas identity before considering a disk entry.
+pcall(function()
+  Assets = require("src.render.Assets")
+  Assets.register(function()
+    sourceDigest = nil
+    atlasDigests = {}
+    Cache.forget()
+  end)
+end)
+
+return Cache

--- a/lib/VoxelScene.lua
+++ b/lib/VoxelScene.lua
@@ -476,14 +476,79 @@ function VoxelScene.prefetch(state)
   -- cut out of that build's own geometry (ChunkMesher.pair), so the two
   -- always come from the same slot and a lake is never drawn twice or left
   -- as a hole.
-  ChunkMesher.request(state.map, false, masks, true)
   local terrain, water = ChunkMesher.pair(state.map, false)
   if not terrain then
     terrain, water = ChunkMesher.pair(state.map, true)
   end
+  if not terrain then
+    -- BODY is enough to leave the flat fallback and is the slot persisted by
+    -- the Android warm-up. Queue it before FULL; a corrupt/missing entry stays
+    -- on the ordinary asynchronous path rather than blocking a transition.
+    ChunkMesher.request(state.map, true, nil, true)
+    ChunkMesher.request(state.map, false, masks,
+                        ChunkMesher.failed(state.map, true))
+  else
+    -- Once terrain is drawable, the border-ring refinement is background work
+    -- and must not steal normal walking frames.
+    ChunkMesher.request(state.map, false, masks, false)
+  end
+
   local nbMesh, nbWater = {}, {}
+  local nearest, nearestD2 = nil, math.huge
+  local front, frontScore = nil, -math.huge
+  local player = state.player
+  local facing = player and player.facing or nil
+  local fx, fy = 0, 0
+  if facing == "up" then fy = -1
+  elseif facing == "down" then fy = 1
+  elseif facing == "left" then fx = -1
+  elseif facing == "right" then fx = 1 end
+
+  if player then
+    local currentW = (state.map.def.width or 0) * 32
+    local currentH = (state.map.def.height or 0) * 32
+    local currentCx, currentCy = currentW * 0.5, currentH * 0.5
+    for i, nb in ipairs(state.neighbors or {}) do
+      local x1, y1 = nb.ox, nb.oy
+      local x2 = x1 + nb.map.def.width * 32
+      local y2 = y1 + nb.map.def.height * 32
+      local dx = (player.px < x1 and x1 - player.px)
+                 or (player.px > x2 and player.px - x2) or 0
+      local dy = (player.py < y1 and y1 - player.py)
+                 or (player.py > y2 and player.py - y2) or 0
+      local d2 = dx * dx + dy * dy
+      if d2 < nearestD2 then nearest, nearestD2 = i, d2 end
+
+      if fx ~= 0 or fy ~= 0 then
+        local nx = nb.ox + nb.map.def.width * 16 - currentCx
+        local ny = nb.oy + nb.map.def.height * 16 - currentCy
+        local len = math.sqrt(nx * nx + ny * ny)
+        if len > 0 then
+          local score = (nx * fx + ny * fy) / len
+          if score > frontScore then front, frontScore = i, score end
+        end
+      end
+    end
+  end
+
   for i, nb in ipairs(state.neighbors or {}) do
-    ChunkMesher.request(nb.map, true)
+    -- Every direct neighbour gets an immediate persistent-cache request.
+    -- Facing priority brings the likely border in first. A cache miss can be
+    -- queued, but the mesher scheduler will not cold-generate it while walking.
+    local cached = ChunkMesher.bodyCachedOnDisk(nb.map)
+    local warm = 0
+    if cached then
+      if i == front and frontScore > 0.20 then
+        warm = 6
+      elseif i == nearest then
+        warm = 4
+      else
+        warm = 2
+      end
+    elseif i == nearest and nearestD2 <= 32 * 32 then
+      warm = 2
+    end
+    ChunkMesher.request(nb.map, true, nil, false, warm)
     nbMesh[i], nbWater[i] = ChunkMesher.pair(nb.map, true)
     if not nbMesh[i] then
       nbMesh[i], nbWater[i] = ChunkMesher.pair(nb.map, false)

--- a/main.lua
+++ b/main.lua
@@ -83,6 +83,7 @@ local Voxel3D = V.require("Voxel3D")
 local VoxelScene = V.require("VoxelScene")
 local TiltShift = V.require("TiltShift")
 local ChunkMesher = V.require("ChunkMesher")
+local VoxelCacheScreen = V.require("VoxelCacheScreen")
 local VoxelGrid = V.require("VoxelGrid")
 local WorldCurve = V.require("WorldCurve")
 local ViewBox = V.require("ViewBox")
@@ -180,6 +181,36 @@ local function sceneSize(ctx)
 end
 
 local voidFill = { last = nil }
+
+-- At high refresh rates, a grid step can contain brief frames where the
+-- engine's moving flag is down. Keep a small grace window so Android never
+-- mistakes those gaps for permission to start a cold neighbour build.
+local IS_ANDROID = false
+pcall(function()
+  IS_ANDROID = love and love.system and love.system.getOS
+               and love.system.getOS() == "Android"
+end)
+local moveProbe = { map = nil, x = nil, y = nil, last = -math.huge }
+local moveClock = (love and love.timer and love.timer.getTime) or os.clock
+local MOVE_GRACE = 0.18
+
+local function overworldMoving(ow)
+  if not IS_ANDROID then return false end
+  local player = ow and ow.player
+  if not (player and ow.map) then
+    moveProbe.map, moveProbe.x, moveProbe.y = nil, nil, nil
+    moveProbe.last = -math.huge
+    return false
+  end
+  local sameMap = moveProbe.map == ow.map.id
+  local moved = sameMap and moveProbe.x ~= nil
+                and (player.px ~= moveProbe.x or player.py ~= moveProbe.y)
+  local active = player.moving == true or moved
+  if active then moveProbe.last = moveClock() end
+  moveProbe.map, moveProbe.x, moveProbe.y = ow.map.id, player.px, player.py
+  return active or (sameMap and moveClock() - moveProbe.last < MOVE_GRACE)
+end
+
 function voidFill.check()
   local TileRenderer = require("src.render.TileRenderer")
   local now = TileRenderer.voidFill
@@ -323,14 +354,21 @@ mod.content.render_pipelines:register("voxel", {
     -- Ahead of the active() gate: with the mode off, the headset still
     -- shows the flat screen on the floating panel.
     VR.update(dt)
+    -- Android prepares large BODY meshes once on an opaque, resumable screen.
+    -- Completion lives in persistent storage, so subsequent launches and
+    -- ordinary traversal only stream bounded cache chunks. Keep this after
+    -- the always-running modes above so the new screen does not pause them.
+    pcall(VoxelCacheScreen.maybePush)
+    if VoxelCacheScreen.active() then return end
     if not Voxel.active() then return end
     local Game = require("src.core.Game")
     local ow = Game and Game.overworld
+    local covered = ((Game and Game.stack and Game.stack:top() ~= ow)
+                     or (ow and ow.transitioning)) and true or false
     if ow and ow.map and ow.camera then
-      pcall(VoxelScene.prefetch, ow)
+      pcall(VoxelScene.prefetch, ow, covered)
     end
-    ChunkMesher.pump(Game and Game.stack
-                     and Game.stack:top() ~= ow)
+    ChunkMesher.pump(covered, not covered and overworldMoving(ow))
   end,
 
   drawWorld = function(ctx)
@@ -365,7 +403,7 @@ mod.content.render_pipelines:register("voxel", {
     -- gen2-gold-beta meshKick diagnostics: once per session, name the map
     -- and force a short pump so a stuck empty cache surfaces as a real
     -- build failure rather than an endless silent 2D fallback.
-    if st and st.map and not V._meshKick then
+    if st and st.map and not V._meshKick and not VoxelCacheScreen.active() then
       V._meshKick = true
       local map = st.map
       local ts = map.tileset
@@ -379,10 +417,17 @@ mod.content.render_pipelines:register("voxel", {
       local okB, errB = pcall(function()
         ChunkMesher.request(map, true, {}, true)
         ChunkMesher.request(map, false, {}, true)
-        for _ = 1, 30 do
-          ChunkMesher.pump(true)
-          if ChunkMesher.pair(map, true) or ChunkMesher.pair(map, false) then
-            break
+        if ChunkMesher.persistentCacheAvailable() then
+          -- A single ordinary-frame slice is enough to diagnose the Android
+          -- path without reinstating the old 30-slice visible-frame stall.
+          ChunkMesher.pump(false, false)
+        else
+          -- Keep the maintained release's diagnostic behaviour on desktop.
+          for _ = 1, 30 do
+            ChunkMesher.pump(true, false)
+            if ChunkMesher.pair(map, true) or ChunkMesher.pair(map, false) then
+              break
+            end
           end
         end
       end)

--- a/tests/dramatic_shape_test.lua
+++ b/tests/dramatic_shape_test.lua
@@ -7254,6 +7254,21 @@ end)()
     .. "pillar, not hanging in the air two cells in front of it")
 end)()
 
+-- ------- persistent Android voxel BODY cache
+
+;(function()
+  local lib = run.loader.exports.DRAMATIC_SHAPE.lib
+  dofile(MOD_PATH .. "/tests/voxel_mesh_cache_test.lua")(
+    T,
+    lib.require("VoxelMeshCache"),
+    lib.require("ChunkMesher"),
+    lib.require("VoxelScene"),
+    lib.require("TerrainAtlas"),
+    lib.require("VoxelCacheScreen"),
+    lib.require("Structures"),
+    MOD_PATH)
+end)()
+
 Pipelines.reset()
 run.release()
 

--- a/tests/voxel_mesh_cache_headless_test.lua
+++ b/tests/voxel_mesh_cache_headless_test.lua
@@ -1,0 +1,25 @@
+-- Standalone entry point for the focused persistent voxel-cache suite.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local T = require("tests.modkit")
+local Data = T.fixtures.load()
+local MOD_PATH = os.getenv("DS_MOD_PATH") or "mods/DramaticShapeVoxelMod"
+local run = T.sdk.loadMod(MOD_PATH, { data = Data })
+
+T.eq(#run.errors, 0,
+  "DRAMATIC_SHAPE loads clean: " .. table.concat(run.errors, "; "))
+
+local lib = run.loader.exports.DRAMATIC_SHAPE.lib
+dofile(MOD_PATH .. "/tests/voxel_mesh_cache_test.lua")(
+  T,
+  lib.require("VoxelMeshCache"),
+  lib.require("ChunkMesher"),
+  lib.require("VoxelScene"),
+  lib.require("TerrainAtlas"),
+  lib.require("VoxelCacheScreen"),
+  lib.require("Structures"),
+  MOD_PATH)
+
+run.release()
+T.finish("DRAMATIC_SHAPE voxel mesh cache")

--- a/tests/voxel_mesh_cache_test.lua
+++ b/tests/voxel_mesh_cache_test.lua
@@ -1,0 +1,365 @@
+-- Focused persistent voxel-cache checks. Loaded by dramatic_shape_test.lua
+-- after the mod so it exercises the runtime module instances.
+
+return function(T, Cache, ChunkMesher, VoxelScene, TerrainAtlas,
+                CacheScreen, Structures, modPath)
+  T.eq(Cache._test.backendName(), "persistence-fs",
+    "current Gen1Recomp exposes the sandbox-safe persistence router")
+
+  local files = {}
+  local compressed = {}
+  local packCalls, zipCalls, unzipCalls = 0, 0, 0
+  local packed = {}
+
+  -- The headless SDK does not emulate love.data. This deterministic codec has
+  -- the same byte-count contract; a separate LOVE test exercises the real
+  -- pack/LZ4/ByteData APIs used on device.
+  local data = {}
+  function data.pack(container, format, ...)
+    if packCalls == 0 then
+      T.eq(container, "string", "voxel vertices pack into strings")
+      T.eq(format, "<ffffff",
+        "voxel vertices use explicit little-endian floats")
+      T.eq(select("#", ...), 6,
+        "one packed voxel vertex contains six floats")
+    end
+    packCalls = packCalls + 1
+    local value = ("%024d"):format(packCalls)
+    packed[#packed + 1] = value
+    return value
+  end
+  function data.compress(container, algorithm, raw)
+    T.eq(container, "string", "persistent voxel chunks compress to strings")
+    T.eq(algorithm, "lz4", "persistent voxel chunks use LOVE's LZ4 codec")
+    zipCalls = zipCalls + 1
+    local key = ("z%07d"):format(zipCalls)
+    compressed[key] = raw
+    return key
+  end
+  function data.decompress(container, algorithm, value)
+    T.eq(container, "string", "persistent voxel chunks decompress to strings")
+    T.eq(algorithm, "lz4", "persistent voxel chunks decode with LZ4")
+    unzipCalls = unzipCalls + 1
+    return assert(compressed[value], "unknown compressed test chunk")
+  end
+  function data.newByteData(value) return value end
+
+  local backend = { android = true, data = data }
+  function backend.read(key) return files[key] end
+  function backend.write(key, value) files[key] = value; return true end
+  function backend.delete(key) files[key] = nil; return true end
+  Cache._test.setBackend(backend)
+
+  local function map(id, width, height, tilesetId, changed)
+    local blocks = {}
+    for i = 1, width * height do blocks[i] = 0 end
+    if changed then blocks[1] = 1 end
+    local blockset = { {}, {} }
+    for i = 1, 16 do
+      blockset[1][i] = (i - 1) % 96
+      blockset[2][i] = i % 96
+    end
+    local result = {
+      id = id,
+      def = {
+        width = width, height = height, tileset = tilesetId,
+        blocks = blocks,
+      },
+      tileset = {
+        id = tilesetId, image = "tiles/" .. tilesetId .. ".png",
+        tilesPerRow = 16, imageWidth = 128, imageHeight = 48,
+        blocks = blockset, grassTile = -1,
+      },
+      walkable = { [0] = true },
+      waterTiles = {}, doorTiles = {}, warpTiles = {}, shoreTiles = {},
+      tileAt = function(self, x, y)
+        local bx, by = math.floor(x / 4), math.floor(y / 4)
+        local block = self.def.blocks[by * width + bx + 1] or 0
+        return blockset[block + 1][(y % 4) * 4 + (x % 4) + 1]
+      end,
+    }
+    function result:cellTile(cx, cy) return self:tileAt(cx * 2, cy * 2 + 1) end
+    function result:inBounds(cx, cy)
+      return cx >= 0 and cy >= 0 and cx < width * 2 and cy < height * 2
+    end
+    function result:isWalkableCell(cx, cy)
+      return self.walkable[self:cellTile(cx, cy)] or false
+    end
+    function result:isWaterCell() return false end
+    function result:isDoorTileCell() return false end
+    function result:isGrassCell() return false end
+    return result
+  end
+
+  local base = map("CACHE_A", 1, 1, "OVERWORLD")
+  local fp = Cache.fingerprint(base, "trees")
+  T.check(type(fp) == "string" and #fp == 8,
+    "a map geometry fingerprint is a stable eight-digit value")
+  T.neq(Cache.fingerprint(map("CACHE_B", 1, 1, "OVERWORLD"), "trees"), fp,
+    "the map id participates in the persistent-cache fingerprint")
+  T.neq(Cache.fingerprint(map("CACHE_A", 2, 1, "OVERWORLD"), "trees"), fp,
+    "map dimensions participate in the persistent-cache fingerprint")
+  T.neq(Cache.fingerprint(map("CACHE_A", 1, 1, "FOREST"), "trees"), fp,
+    "the tileset participates in the persistent-cache fingerprint")
+  T.neq(Cache.fingerprint(map("CACHE_A", 1, 1, "OVERWORLD", true), "trees"), fp,
+    "the live tile layout participates in the persistent-cache fingerprint")
+  local borderChanged = map("CACHE_A", 1, 1, "OVERWORLD")
+  borderChanged.def.borderBlock = 7
+  T.neq(Cache.fingerprint(borderChanged, "trees"), fp,
+    "border geometry participates in the persistent-cache fingerprint")
+  T.neq(Cache.fingerprint(base, "black"), fp,
+    "void fill participates in the persistent-cache fingerprint")
+
+  -- A ready marker is the commit point. Its explicit schema and geometry
+  -- versions are both rejected before any chunk is opened.
+  local schemaMap = map("CACHE_SCHEMA", 1, 1, "OVERWORLD")
+  local schemaFp = Cache.fingerprint(schemaMap)
+  local schemaReady = Cache._test.keys(schemaMap)
+  files[schemaReady] = Cache._test.readyBody(
+      schemaFp, 6, 1, 0, 0, Cache.SCHEMA_VERSION + 1)
+  T.eq(Cache.status(schemaMap), false,
+    "a persistent voxel entry from another schema version is rejected")
+  files[schemaReady] = Cache._test.readyBody(
+      schemaFp, 6, 1, 0, 0, Cache.SCHEMA_VERSION, "other-geometry")
+  Cache.forget(schemaMap.id)
+  T.eq(Cache.status(schemaMap), false,
+    "an entry from another geometry version is rejected")
+
+  -- Exercise the real mesher-to-cache path without a GPU. The Android cold
+  -- BODY path must write bounded persistent chunks directly, not construct a
+  -- synchronous full neighbour mesh in Lua tables first.
+  local generated = map("CACHE_GENERATED", 1, 1, "OVERWORLD")
+  local realLoveData = love.data
+  local realNewMesh = love.graphics.newMesh
+  love.data = data
+  love.graphics.newMesh = function()
+    error("precompileBody must not allocate a GPU mesh")
+  end
+  local generatedOk, generatedWhy = ChunkMesher.precompileBody(generated)
+  love.data = realLoveData
+  love.graphics.newMesh = realNewMesh
+  T.check(generatedOk, "the headless voxel mesher writes BODY cache chunks: "
+          .. tostring(generatedWhy))
+  T.check(Cache.status(generated),
+    "headless generated voxel BODY geometry receives a durable ready marker")
+  packed, packCalls = {}, 0
+
+  local corners = {
+    { 0, 0, 0 }, { 1, 0, 0 }, { 1, 1, 0 }, { 0, 1, 0 },
+  }
+  local uv = { { 0, 0 }, { 1, 0 }, { 1, 1 }, { 0, 1 } }
+  local store = assert(Cache.beginStore(base))
+  local bodySink, waterSink = store:sink("body"), store:sink("water")
+  local bodyPacks = 684 * 6 -- 4,104: deliberately crosses a chunk boundary
+  for _ = 1, 684 do bodySink.push(corners, uv, 0.75) end
+  local bodyExpected = table.concat(packed, "", 1, bodyPacks)
+  waterSink.push(corners, uv, { 1, 0.9, 0.8, 0.7 })
+  local waterExpected = table.concat(packed, "", bodyPacks + 1, #packed)
+  T.check(store:commit(), "BODY and water vertex streams serialize successfully")
+  local hit, _, meta = Cache.status(base)
+  T.check(hit, "the completed per-map marker makes the entry valid")
+  T.eq(meta.bodyChunks, 2, "large BODY geometry is split into bounded chunks")
+  T.eq(meta.waterChunks, 1, "water has an independent bounded stream")
+
+  local writes = {}
+  local function receiver(kind, count)
+    local parts = {}
+    return {
+      write = function(_, raw, first, n)
+        parts[#parts + 1] = raw
+        writes[#writes + 1] = { kind = kind, first = first, count = n,
+                                bytes = #raw }
+      end,
+      finish = function() return table.concat(parts) end,
+      abort = function() parts = {} end,
+    }
+  end
+  local loaded, gotBody, gotWater = Cache.load(base, receiver)
+  T.check(loaded, "a complete persistent voxel entry deserializes")
+  T.eq(gotBody, bodyExpected, "BODY vertices survive serialize -> deserialize")
+  T.eq(gotWater, waterExpected, "water vertices survive serialize -> deserialize")
+  T.eq(#writes, 3, "decompression and upload are exposed as bounded chunk units")
+  T.check(zipCalls >= 3 and unzipCalls >= 3,
+    "the round trip crossed independently LZ4-compressed cache chunks")
+
+  -- A restart loses RAM memo state, not completed per-map work. The unfinished
+  -- second map remains missing, which is where preparation resumes.
+  Cache._test.setBackend(backend)
+  T.check(Cache.status(base), "a completed map remains cached after a restart")
+  local second = map("CACHE_SECOND", 1, 1, "OVERWORLD")
+  T.eq(Cache.status(second), false,
+    "an interrupted warm-up resumes with only its missing maps")
+  local signature = Cache.warmupSignature({ "CACHE_A", "CACHE_SECOND" }, "trees")
+  T.check(Cache.markWarmupComplete(signature) and Cache.warmupComplete(signature),
+    "a finished warm-up records its versioned candidate signature")
+  local secondStore = assert(Cache.beginStore(second))
+  secondStore:sink("body").push(corners, uv, 1)
+  T.check(secondStore:commit(), "a missing warm-up map commits independently")
+  T.eq(Cache.warmupComplete(signature), false,
+    "new geometry clears a now-stale warm-up completion marker")
+
+  -- The preparation screen skips an already completed map and resumes a
+  -- suspended per-map coroutine on the next update instead of restarting it.
+  local MapLoader = require("src.world.MapLoader")
+  local screenOriginals = {
+    load = MapLoader.load,
+    trim = MapLoader.trim,
+    cached = ChunkMesher.bodyCachedOnDisk,
+    precompile = ChunkMesher.precompileBody,
+    structures = Structures.invalidate,
+  }
+  local precompileSteps = 0
+  MapLoader.load = function(_, id) return map(id, 6, 4, "OVERWORLD") end
+  MapLoader.trim = function() end
+  Structures.invalidate = function() end
+  ChunkMesher.bodyCachedOnDisk = function(value)
+    return value.id == "WARM_ALREADY_DONE"
+  end
+  ChunkMesher.precompileBody = function(value)
+    T.eq(value.id, "WARM_RESUME", "warm-up builds the first missing map")
+    precompileSteps = precompileSteps + 1
+    coroutine.yield("test-slice")
+    precompileSteps = precompileSteps + 1
+    return true, "built"
+  end
+  local warmSignature = Cache.warmupSignature(
+      { "WARM_ALREADY_DONE", "WARM_RESUME" })
+  local fakeStack = {}
+  local warmGame = { data = {}, input = {}, stack = fakeStack }
+  local screen = CacheScreen.new(
+      warmGame, { "WARM_ALREADY_DONE", "WARM_RESUME" }, warmSignature)
+  fakeStack.top = function() return screen end
+  fakeStack.pop = function() end
+  screen:enter()
+  screen:update()
+  T.eq(screen.done, 1, "warm-up preserves and skips an already cached map")
+  T.eq(precompileSteps, 1,
+    "an unfinished map yields after its first bounded preparation slice")
+  screen:update()
+  T.eq(screen.done, 2, "the next update resumes and completes that map")
+  T.eq(precompileSteps, 2, "resumable preparation continues the same coroutine")
+  screen:update()
+  T.check(screen.finished and Cache.warmupComplete(warmSignature),
+    "the all-maps marker is committed only after resumed work completes")
+  screen:exit()
+  CacheScreen._reset()
+  MapLoader.load = screenOriginals.load
+  MapLoader.trim = screenOriginals.trim
+  ChunkMesher.bodyCachedOnDisk = screenOriginals.cached
+  ChunkMesher.precompileBody = screenOriginals.precompile
+  Structures.invalidate = screenOriginals.structures
+
+  local changed = map("CACHE_A", 1, 1, "OVERWORLD", true)
+  T.eq(Cache.status(changed), false,
+    "a layout fingerprint mismatch rejects otherwise compatible cache data")
+
+  -- The ready marker may enqueue a load before payload validation. A truncated
+  -- chunk must remove that marker and return a miss without escaping an error.
+  Cache.forget(base.id)
+  T.check(Cache.status(base), "a valid ready marker can enqueue a cache read")
+  local _, bodyKey, completeKey = Cache._test.keys(base, "body", 1)
+  files[completeKey] = signature
+  files[bodyKey] = files[bodyKey]:sub(1, math.max(1, #files[bodyKey] - 9))
+  Cache.forget(base.id)
+  local safe, corruptOk = pcall(Cache.load, base, receiver)
+  T.check(safe and corruptOk == false,
+    "a truncated cache falls back safely instead of throwing")
+  Cache.forget(base.id)
+  T.eq(Cache.status(base), false,
+    "a corrupt cache loses its per-map completion marker")
+  T.eq(files[completeKey], nil,
+    "corruption also clears the all-maps warm-up marker")
+
+  -- Runtime invalidation clears status memoization. It does not destroy the
+  -- global base-map entry; another save whose layout still matches may reuse it.
+  local rebuilt = assert(Cache.beginStore(base))
+  rebuilt:sink("body").push(corners, uv, 1)
+  T.check(rebuilt:commit(), "the cache can be rebuilt after corruption")
+  local readyKey = Cache._test.keys(base)
+  T.check(Cache.status(base), "the rebuilt cache status is memoized")
+  files[readyKey] = nil
+  T.check(Cache.status(base), "the status memo is active before invalidation")
+  ChunkMesher.invalidate(base.id)
+  T.eq(Cache.status(base), false,
+    "Cut/door/reload invalidation also clears persistent-cache status")
+
+  local scheduler = ChunkMesher._test
+  T.eq(scheduler.walkingAllows({ persistent = false }, false, true), false,
+    "normal Android walking does not generate a cold neighbour mesh")
+  T.check(scheduler.walkingAllows({ persistent = true }, false, true),
+    "normal Android walking may stream a cached neighbour BODY")
+  T.check(scheduler.walkingAllows({ persistent = false }, true, false),
+    "a missing current-map BODY retains a small urgent recovery slice")
+  T.eq(scheduler.walkingAllows({ persistent = true, terrainReady = true },
+                               false, true), false,
+    "optional work after terrain is visible stays paused while walking")
+
+  -- Exercise prefetch with two direct neighbours. Both cached BODY requests
+  -- are submitted immediately; the facing neighbour receives top priority.
+  local requested = {}
+  local originals = {
+    request = ChunkMesher.request,
+    pair = ChunkMesher.pair,
+    failed = ChunkMesher.failed,
+    cached = ChunkMesher.bodyCachedOnDisk,
+    live = ChunkMesher.setLive,
+    atlasLive = TerrainAtlas.setLive,
+  }
+  ChunkMesher.setLive = function() end
+  TerrainAtlas.setLive = function() end
+  ChunkMesher.pair = function() return nil, nil end
+  ChunkMesher.failed = function() return false end
+  ChunkMesher.bodyCachedOnDisk = function() return true end
+  ChunkMesher.request = function(mapValue, bodyOnly, masks, urgent, warm)
+    requested[#requested + 1] = {
+      id = mapValue.id, body = bodyOnly, masks = masks,
+      urgent = urgent, warm = warm,
+    }
+  end
+  local current = map("PREFETCH_CURRENT", 4, 4, "OVERWORLD")
+  local east = map("PREFETCH_EAST", 4, 4, "OVERWORLD")
+  local west = map("PREFETCH_WEST", 4, 4, "OVERWORLD")
+  VoxelScene.prefetch({
+    map = current,
+    player = { px = 112, py = 64, facing = "right" },
+    neighbors = {
+      { map = east, ox = 128, oy = 0 },
+      { map = west, ox = -128, oy = 0 },
+    },
+  })
+  ChunkMesher.request = originals.request
+  ChunkMesher.pair = originals.pair
+  ChunkMesher.failed = originals.failed
+  ChunkMesher.bodyCachedOnDisk = originals.cached
+  ChunkMesher.setLive = originals.live
+  TerrainAtlas.setLive = originals.atlasLive
+  local neighbourWarm = {}
+  for _, request in ipairs(requested) do
+    if request.id ~= current.id and request.body then
+      neighbourWarm[request.id] = request.warm
+    end
+  end
+  T.check((neighbourWarm.PREFETCH_EAST or 0) > 0
+          and (neighbourWarm.PREFETCH_WEST or 0) > 0,
+    "every direct neighbour is prefetched early from persistent BODY cache")
+  T.check(neighbourWarm.PREFETCH_EAST > neighbourWarm.PREFETCH_WEST,
+    "the neighbour in front of the player receives higher upload priority")
+
+  local file = assert(io.open(modPath .. "/lib/VoxelScene.lua", "rb"))
+  local sceneSource = file:read("*a")
+  file:close()
+  local prefetchStart = sceneSource:find("function VoxelScene.prefetch", 1, true)
+  local prefetchEnd = prefetchStart
+      and sceneSource:find("-- Capture every entity", prefetchStart, true)
+  local prefetch = (prefetchStart and prefetchEnd)
+      and sceneSource:sub(prefetchStart, prefetchEnd - 1) or ""
+  T.check(#prefetch > 0, "the traversal prefetch function is inspectable")
+  T.eq(prefetch:find("ChunkMesher.get", 1, true), nil,
+    "the walking prefetch path never calls the synchronous mesh getter")
+  T.eq(prefetch:find("ChunkMesher.build", 1, true), nil,
+    "the walking prefetch path never calls the synchronous mesh builder")
+  T.eq(sceneSource:find("forceTerrain", 1, true), nil,
+    "no synchronous transition force-build path was introduced")
+
+  Cache._test.clearBackend()
+end


### PR DESCRIPTION
I’ve been testing Dramatic Shape on Android and the main issue I kept running into was voxel generation happening during normal traversal. On cold maps this could show the void/2D fallback for a moment, while making the mesher more aggressive just traded that for stutters or large freezes.

This adds a persistent cache for the generated BODY meshes. The expensive voxel geometry is prepared once, stored in the mod’s persistence directory, and reused on later runs. Neighbouring cached maps can then be loaded progressively instead of being regenerated while the player is walking.

The cache is versioned and fingerprinted so stale or corrupt entries fall back to a rebuild. Loading and GPU uploads are also chunked to avoid replacing the generation hitch with an upload hitch.

I tested this exact branch on a physical Android device with the current Gen1Recomp runtime. After the initial cache preparation, walking and route/city transitions are smooth, cached neighbouring maps are ready before reaching their borders, and I no longer get the multi-second freezes from synchronous generation.

The focused cache tests pass 76/76. The full suite has the same 30 pre-existing failures as an untouched v1.8.4 checkout.

This addresses the Android performance side of the old issue #10.
