### PR TITLE
Release 1.8.5: Android persistent voxel mesh cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.8.5
+
+### Added
+
+- **Persistent BODY mesh cache (Android-focused performance).**
+  Expensive voxel geometry is prepared once, stored under the mod’s persistence directory, and reused across sessions. The cache is versioned and fingerprinted so stale or corrupt entries fall back to a rebuild. Neighbouring cached maps load progressively; loading and GPU uploads are chunked to avoid replacing a generation hitch with an upload hitch. After the initial cache preparation, walking and route/city transitions are smooth on device and the multi-second freezes from synchronous generation are eliminated. Addresses the Android performance side of the old issue #10.
+
 ## 1.8.4
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "DRAMATIC_SHAPE",
   "name": "Dramatic Shape Voxel Mod",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "api": 2,
   "entry": "main.lua",
   "profile": "content",


### PR DESCRIPTION
Bump to 1.8.5 and document the latest performance work.

### Changes in 1.8.5

- **Added** persistent BODY mesh cache for voxel geometry.
  - Expensive terrain meshes are generated once, versioned + fingerprinted, and stored in the mod’s persistence directory.
  - Cached neighboring maps load progressively instead of regenerating while the player is walking.
  - Loading and GPU uploads are chunked so generation hitches are not simply replaced by upload hitches.
  - Stale or corrupt cache entries fall back to a rebuild.
  - Tested on device with current Gen1Recomp: after the initial cache build, walking and route/city transitions are smooth and multi-second freezes from synchronous generation are gone.
  - Addresses the Android performance side of the old issue #10.

Only the two packaging files that change for the version bump + changelog are included in the zip (`CHANGELOG.md` + `manifest.json`). All functional changes from the cache PR are already on `dev`.
